### PR TITLE
Refactor Sbom.to_dict() to improve readability.

### DIFF
--- a/src/main/data_types/sbom_types/sbom.py
+++ b/src/main/data_types/sbom_types/sbom.py
@@ -50,15 +50,18 @@ class Sbom:
         Returns:
             dict: The SBOM object as a dictionary.
         """
-        return {
-            "serialNumber": self.serial_number,
-            "version": self.version,
-            "repo_name": self.repo_name,
-            "repo_version": self.repo_version,
-            "dependencies": [
-                self.dependency_manager.to_dict()
-            ]
-        }
+        res = {}
+        res["serialNumber"] = self.serial_number
+        res["version"] = self.version
+        res["repo_name"] = self.repo_name
+        res["repo_version"] = self.repo_version
+
+        # Add dependencies to the dictionary
+        dependencies = self.dependency_manager.to_dict()
+        for key, value in dependencies.items():
+            res[key] = value
+
+        return res
 
     def _check_format_of_sbom(self, sbom_file: dict) -> None:
         """

--- a/src/tests/main/unit/data_types/sbom_types/test_sbom.py
+++ b/src/tests/main/unit/data_types/sbom_types/test_sbom.py
@@ -71,7 +71,9 @@ def test_sbom_to_dict(sbom_from_json):
     assert "version" in sbom_dict.keys()
     assert "repo_name" in sbom_dict.keys()
     assert "repo_version" in sbom_dict.keys()
-    assert "dependencies" in sbom_dict.keys()
+    assert "scored_dependencies" in sbom_dict.keys()
+    assert "unscored_dependencies" in sbom_dict.keys()
+    assert "failed_dependencies" in sbom_dict.keys()
 
 
 def test_sbom_validation(sbom_bad):


### PR DESCRIPTION
This PR removes the layer with the key "dependency" in the Sbom.to_dict().

Should the key names also change? - i.e scored_dependency -> scored for example