### PR TITLE
Convert windows line endings to unix in tests Dockerfile

### DIFF
--- a/src/tests/Dockerfile
+++ b/src/tests/Dockerfile
@@ -7,6 +7,10 @@ COPY src .
 COPY pytest.ini .
 COPY .coveragerc .
 
+# Convert windows line endings to unix in bash scripts
+RUN apk add --no-cache dos2unix
+RUN dos2unix /app/tests/run.sh
+
 # Create, activate, and setup python virtual environment
 RUN python3 -m venv /app/venv
 ENV PATH="/app/venv/bin:$PATH"


### PR DESCRIPTION
This PR adds two lines in the tests Dockerfile that convert windows line endings (CRLF) to unix line endings (LF) in the bash script for running tests. With this change everyone should be able to run the tests via Docker.