### PR TITLE
Remove async from backend comm

### DIFF
--- a/src/main/backend_communication.py
+++ b/src/main/backend_communication.py
@@ -31,7 +31,7 @@ class BackendCommunication:
         self.on_status_changed.subscribe(callback)
         self.backend_fetcher = BackendFetcher(callback)
 
-    async def add_sbom(self, sbom: Sbom) -> None:
+    def add_sbom(self, sbom: Sbom) -> None:
         """
         Adds an SBOM, its dependencies, and their scores to the database.
 

--- a/src/main/backend_communication.py
+++ b/src/main/backend_communication.py
@@ -39,7 +39,11 @@ class BackendCommunication:
             sbom (Sbom): The SBOM to add to the database.
         """
         try:
-            requests.post(HOST + "/sbom", json=sbom.to_dict(), timeout=5)
+            resp = requests.post(HOST + "/sbom", json=sbom.to_dict(), timeout=5)
+            if resp.status_code == 500:
+                self.on_status_changed.invoke(
+                    StepResponse(0, 0, 0, 0, "The sbom could not be uploaded")
+                )
         except requests.exceptions.Timeout:
             # Tell the user that the request timed out
             self.on_status_changed.invoke(

--- a/src/main/sbom_processor.py
+++ b/src/main/sbom_processor.py
@@ -106,7 +106,6 @@ class SbomProcessor:
         Args:
             sbom (Sbom): The SBOM to analyze.
         """
-        # TODO
         # 1. Get score from BackendScorer
         self._set_event_state(SbomProcessorStates.FETCH_DATABASE)
         self._run_dependency_scorer(

--- a/src/main/sbom_processor.py
+++ b/src/main/sbom_processor.py
@@ -33,6 +33,7 @@ class SbomProcessorStates(StrEnum):
     COMPLETED = "Completed"
     FAILED = "Failed"
     CANCELLED = "Cancelled"
+    UPLOADING_SCORES = "Uploading Scores"
 
 
 @dataclass
@@ -122,8 +123,9 @@ class SbomProcessor:
             sbom, ScorecardAnalyzer(self._event_callback)
             )
         # 4. Update database with new scores
-        self._set_event_state(SbomProcessorStates.COMPLETED)
+        self._set_event_state(SbomProcessorStates.UPLOADING_SCORES)
         self.backend_communication.add_sbom(sbom)
+        self._set_event_state(SbomProcessorStates.COMPLETED)
         return sbom
 
     def lookup_stored_sboms(self) -> list[str]:


### PR DESCRIPTION
This PR removes async from the function ```add_sbom``` in ```backend_communication.py```. This was done because it does not matter whether it is async or not, since the program needs to wait for the function to finish anyway, because it is the last thing the program does when it analyzes an SBOM.