### PR TITLE
Update result display to match new project structure

### DIFF
--- a/src/frontend/OSSQAWebAPI/OSSQAWebAPI/Components/Pages/FailedComponents.razor
+++ b/src/frontend/OSSQAWebAPI/OSSQAWebAPI/Components/Pages/FailedComponents.razor
@@ -1,7 +1,0 @@
-﻿@page "/failed"
-
-<h3>FailedComponents</h3>
-
-@code {
-
-}

--- a/src/frontend/OSSQAWebAPI/OSSQAWebAPI/Components/Pages/FailedComponents.razor
+++ b/src/frontend/OSSQAWebAPI/OSSQAWebAPI/Components/Pages/FailedComponents.razor
@@ -1,0 +1,7 @@
+﻿@page "/failed"
+
+<h3>FailedComponents</h3>
+
+@code {
+
+}

--- a/src/frontend/OSSQAWebAPI/OSSQAWebAPI/Components/Pages/Home.razor
+++ b/src/frontend/OSSQAWebAPI/OSSQAWebAPI/Components/Pages/Home.razor
@@ -4,7 +4,8 @@
 @rendermode InteractiveServer
 @using System.Text
 @using static SbomAnalysis.Check
-
+@using static SbomAnalysis.Dependency
+@using static SbomAnalysis.Status
 <PageTitle>OSSQA</PageTitle>
 <MatThemeProvider Theme="@theme">
 @if (Analyzing.CurrentCount == 1 && SbomResult.Count > 0)
@@ -17,16 +18,16 @@
             <ViewResults SbomResult="SbomResult" Tests='["Vulnerabilities"]' />
         </MatTab>
         <MatTab Label="Maintenance">
-            <ViewResults SbomResult="SbomResult" Tests='["CII-Best-Practices", "Dependency-Update-Tool", "License", "Maintained", "Security-Policy"]' />
+            <ViewResults SbomResult="SbomResult" Tests='[ "License", "Security-Policy"]' />
         </MatTab>
         <MatTab Label="Continuous Testing">
-            <ViewResults SbomResult="SbomResult" Tests='["CI-Tests", "Fuzzing", "SAST"]' />
+            <ViewResults SbomResult="SbomResult" Tests='["CI-Tests"]' />
         </MatTab>
         <MatTab Label="Source Risk Assessment">
-            <ViewResults SbomResult="SbomResult" Tests='["Binary-Artifacts", "Branch-Protection", "Code-Review", "Contributors", "Dangerous-Workflow"]' />
+            <ViewResults SbomResult="SbomResult" Tests='["Binary-Artifacts", "Code-Review", "Dangerous-Workflow"]' />
         </MatTab>
         <MatTab Label="Build Risk Assessment">
-            <ViewResults SbomResult="SbomResult" Tests='["Packaging", "Pinned-Dependencies", "Signed-Releases", "Token-Permissions"]' />
+            <ViewResults SbomResult="SbomResult" Tests='[ "Pinned-Dependencies", "Token-Permissions"]' />
                 </MatTab>
     </MatTabGroup>
 }
@@ -43,10 +44,10 @@ else if(!ready)
 }
 else
 {
-    <SbomAnalysis SbomResult="SbomResult" Analyzing="Analyzing" StateHasChangedCallback="StateHasChangedCallback" PostData="PostData" />
+        <SbomAnalysis SbomResult="SbomResult" Analyzing="Analyzing" StateHasChangedCallback="StateHasChangedCallback" PostData="PostData" FailedDependencies="FailedDependencies" />
 }
-</MatThemeProvider>
 
+</MatThemeProvider>
 
 
 @code {
@@ -54,6 +55,7 @@ else
     StringBuilder ChosenSbom = new StringBuilder();
     private SemaphoreSlim Analyzing = new(1, 1);
     private List<int> Requirements = new() { -1, -1, -1, -1, -1 };
+    private List<SbomAnalysis.Dependency> FailedDependencies = new();
     private Action StateHasChangedCallback =>()=>
     {
         UpdateTab();

--- a/src/frontend/OSSQAWebAPI/OSSQAWebAPI/Components/Pages/Home.razor
+++ b/src/frontend/OSSQAWebAPI/OSSQAWebAPI/Components/Pages/Home.razor
@@ -8,6 +8,9 @@
 @using static SbomAnalysis.Status
 <PageTitle>OSSQA</PageTitle>
 <MatThemeProvider Theme="@theme">
+@*This class stores all information that will otherwise get wiped when refreshing components *@
+
+    @*shows correct tabs if analysis is complete*@
 @if (Analyzing.CurrentCount == 1 && SbomResult.Count > 0)
 {
     <MatTabGroup>
@@ -31,6 +34,7 @@
                 </MatTab>
     </MatTabGroup>
 }
+    @* if the user has not chosen sbom or requirements *@
 else if(!ready)
 {
     <MatTabGroup @bind-ActiveIndex="@activeTab">
@@ -42,6 +46,7 @@ else if(!ready)
         </MatTab>
     </MatTabGroup>
 }
+    @* start analysis if done *@
 else
 {
         <SbomAnalysis SbomResult="SbomResult" Analyzing="Analyzing" StateHasChangedCallback="StateHasChangedCallback" PostData="PostData" FailedDependencies="FailedDependencies" />

--- a/src/frontend/OSSQAWebAPI/OSSQAWebAPI/Components/Pages/InputSBOM.razor
+++ b/src/frontend/OSSQAWebAPI/OSSQAWebAPI/Components/Pages/InputSBOM.razor
@@ -1,5 +1,8 @@
 ﻿@using System.Text.Json
 @using System.Text;
+
+@* this component handles user SBOM input and reads the sbom file as a string *@
+
 <ViewLogo />
 
 <div class="d-flex flex-column justify-content-center align-items-center">

--- a/src/frontend/OSSQAWebAPI/OSSQAWebAPI/Components/Pages/SbomAnalysis.razor
+++ b/src/frontend/OSSQAWebAPI/OSSQAWebAPI/Components/Pages/SbomAnalysis.razor
@@ -13,15 +13,19 @@
 
 @if(statusObj is not null)
 {
-    <div class="d-flex flex-column align-items-center justify-content-center">
-        <h1>@statusObj.current_state</h1>
-        <h2>@statusObj.step_response.message</h2>
-        <h3>Batch Size: @statusObj.step_response.batch_size</h3>
-        <h3>Completed Items: @statusObj.step_response.completed_items</h3>
-        <h3>Successful Items: @statusObj.step_response.successful_items</h3>
-        <h3>Failed Items: @statusObj.step_response.failed_items</h3>
-    </div>
+    if(statusObj.step_response is not null)
+    {
+        <div class="d-flex flex-column align-items-center justify-content-center">
+            <h1>@statusObj.current_state</h1>
+            <h2>@statusObj.step_response.message</h2>
+            <h3>Batch Size: @statusObj.step_response.batch_size</h3>
+            <h3>Completed Items: @statusObj.step_response.completed_items</h3>
+            <h3>Successful Items: @statusObj.step_response.successful_items</h3>
+            <h3>Failed Items: @statusObj.step_response.failed_items</h3>
+        </div>
+    }
 }
+   
 else
 {
     <div class="d-flex flex-column align-items-center justify-content-center">
@@ -68,56 +72,34 @@ else
     }
     private async Task Analyze()
     {
-        if (PostData is not null && PostData.ContainsKey("sbom"))
+        var analyzeTask = Http.PostAsJsonAsync("http://host.docker.internal:98/analyze", PostData);
+
+        Analyzing.Wait();
+        _ = analyzeTask.ContinueWith(async t =>
         {
-            SbomResult.Clear();
-            var SBOMString = PostData["sbom"];
-            fullSBOM = SBOMString;
-
-            try
+            Analyzing.Release();
+            HttpResponseMessage result = await t;
+            if (result.IsSuccessStatusCode)
             {
-                Sbom sbom = JsonSerializer.Deserialize<Sbom>(SBOMString);
-                AddToDict(sbom);
+                SbomResult.Clear();
+                var SBOMString = await result.Content.ReadAsStringAsync();
+                fullSBOM = SBOMString;
 
-            }
-            catch (Exception e)
-            {
-                throw (e);
-            }
-            StateHasChangedCallback.Invoke();
-            StateHasChanged();
-        }
-        else
-        {
-            var analyzeTask = Http.PostAsJsonAsync("http://host.docker.internal:98/analyze", PostData);
-
-            Analyzing.Wait();
-            _ = analyzeTask.ContinueWith(async t =>
-            {
-                Analyzing.Release();
-                HttpResponseMessage result = await t;
-                if (result.IsSuccessStatusCode)
+                try
                 {
-                    SbomResult.Clear();
-                    var SBOMString = await result.Content.ReadAsStringAsync();
-                    fullSBOM = SBOMString;
+                    Sbom sbom = JsonSerializer.Deserialize<Sbom>(SBOMString);
+                    AddToDict(sbom);
 
-                    try
-                    {
-                        Sbom sbom = JsonSerializer.Deserialize<Sbom>(SBOMString);
-                        AddToDict(sbom);
-
-                    }
-                    catch (Exception e)
-                    {
-                        throw (e);
-                    }
-                    StateHasChangedCallback.Invoke();
-                    StateHasChanged();
                 }
-            });
-            _ = PollStatus(Analyzing);
-        }
+                catch (Exception e)
+                {
+                    throw (e);
+                }
+                StateHasChangedCallback.Invoke();
+                StateHasChanged();
+            }
+        });
+        _ = PollStatus(Analyzing);
     }
     private void AddToDict(Sbom sbom)
     {

--- a/src/frontend/OSSQAWebAPI/OSSQAWebAPI/Components/Pages/SbomAnalysis.razor
+++ b/src/frontend/OSSQAWebAPI/OSSQAWebAPI/Components/Pages/SbomAnalysis.razor
@@ -25,7 +25,7 @@
         </div>
     }
 }
-   
+
 else
 {
     <div class="d-flex flex-column align-items-center justify-content-center">
@@ -139,7 +139,7 @@ else
             }
             catch(Exception e)
             {
-                throw(e);  
+                throw(e);
             }
 
 

--- a/src/frontend/OSSQAWebAPI/OSSQAWebAPI/Components/Pages/SbomAnalysis.razor
+++ b/src/frontend/OSSQAWebAPI/OSSQAWebAPI/Components/Pages/SbomAnalysis.razor
@@ -6,12 +6,14 @@
 @using System.Net.Http.Headers
 @inject NavigationManager _navigationManager
 
-<ViewLogo />
+@* this component sends requests to the backend and retrives the analyzed sbom*@
 
+<ViewLogo />
 
 
 @if (statusObj is not null)
 {
+    @* if the status has a step_response, display it *@
     if (statusObj.step_response is not null)
     {
         <div class="d-flex flex-column align-items-center justify-content-center">
@@ -31,6 +33,7 @@
     }
 }
 
+@* if the analysis is not complete, show loading circle*@
 @if (Analyzing.CurrentCount == 0)
 {
 
@@ -38,12 +41,14 @@
         <MatProgressCircle Indeterminate="true" Size="MatProgressCircleSize.Medium" />
     </div>
 }
+@* if analysis is done, show button for re-run*@
 else
 {
     <div class="d-flex flex-column align-items-center justify-content-center">
         <MatButton OnClick='()=> _navigationManager.NavigateTo("/", true)'> Analyze another SBOM</MatButton>
     </div>
 }
+@* show failed dependencies and reason, not working at the moment*@
 <div class="d-flex flex-column align-items-center justify-content-center">
     <div class="d-flex flex-column">
         @if (FailedDependencies is not null && FailedDependencies.Count > 0)

--- a/src/frontend/OSSQAWebAPI/OSSQAWebAPI/Components/Pages/SbomAnalysis.razor
+++ b/src/frontend/OSSQAWebAPI/OSSQAWebAPI/Components/Pages/SbomAnalysis.razor
@@ -11,9 +11,23 @@
 
 
 
-<div class="d-flex flex-column align-items-center justify-content-center">
-    <p>@status</p>
-</div>
+@if(statusObj is not null)
+{
+    <div class="d-flex flex-column align-items-center justify-content-center">
+        <h1>@statusObj.current_state</h1>
+        <h2>@statusObj.step_response.message</h2>
+        <h3>Batch Size: @statusObj.step_response.batch_size</h3>
+        <h3>Completed Items: @statusObj.step_response.completed_items</h3>
+        <h3>Successful Items: @statusObj.step_response.successful_items</h3>
+        <h3>Failed Items: @statusObj.step_response.failed_items</h3>
+    </div>
+}
+else
+{
+    <div class="d-flex flex-column align-items-center justify-content-center">
+        <h1>Waiting for analysis to complete</h1>
+    </div>
+}
 
 @if(Analyzing.CurrentCount == 0)
 {
@@ -28,6 +42,8 @@ else
         <MatButton OnClick='()=> _navigationManager.NavigateTo("/", true)'> Analyze another SBOM</MatButton>
     </div>
 }
+<p>@fullSBOM</p>
+
 
 
 
@@ -36,6 +52,7 @@ else
     private float score = 0;
     Dictionary<string, string> statusInfo = new();
     string status = "hej baby";
+    private string fullSBOM = "";
     private Status statusObj ;
     [Parameter]
     public SemaphoreSlim Analyzing { get; set; }
@@ -51,45 +68,68 @@ else
     }
     private async Task Analyze()
     {
-        var analyzeTask = Http.PostAsJsonAsync("http://host.docker.internal:98/analyze", PostData);
-
-        Analyzing.Wait();
-        _ = analyzeTask.ContinueWith(async t =>
+        if (PostData is not null && PostData.ContainsKey("sbom"))
         {
-            Analyzing.Release();
-            HttpResponseMessage result = await t;
-            if (result.IsSuccessStatusCode)
+            SbomResult.Clear();
+            var SBOMString = PostData["sbom"];
+            fullSBOM = SBOMString;
+
+            try
             {
-                SbomResult.Clear();
-                var SBOMString = await result.Content.ReadAsStringAsync();
+                Sbom sbom = JsonSerializer.Deserialize<Sbom>(SBOMString);
+                AddToDict(sbom);
 
-                try
-                {
-                    Sbom sbom = JsonSerializer.Deserialize<Sbom>(SBOMString);
-                    AddToDict(sbom);
-
-                }
-                catch (Exception e)
-                {
-                    throw(e);
-                }
-                StateHasChangedCallback.Invoke();
-                StateHasChanged();
             }
-        });
-        _ = PollStatus(Analyzing);
+            catch (Exception e)
+            {
+                throw (e);
+            }
+            StateHasChangedCallback.Invoke();
+            StateHasChanged();
+        }
+        else
+        {
+            var analyzeTask = Http.PostAsJsonAsync("http://host.docker.internal:98/analyze", PostData);
 
+            Analyzing.Wait();
+            _ = analyzeTask.ContinueWith(async t =>
+            {
+                Analyzing.Release();
+                HttpResponseMessage result = await t;
+                if (result.IsSuccessStatusCode)
+                {
+                    SbomResult.Clear();
+                    var SBOMString = await result.Content.ReadAsStringAsync();
+                    fullSBOM = SBOMString;
+
+                    try
+                    {
+                        Sbom sbom = JsonSerializer.Deserialize<Sbom>(SBOMString);
+                        AddToDict(sbom);
+
+                    }
+                    catch (Exception e)
+                    {
+                        throw (e);
+                    }
+                    StateHasChangedCallback.Invoke();
+                    StateHasChanged();
+                }
+            });
+            _ = PollStatus(Analyzing);
+        }
     }
     private void AddToDict(Sbom sbom)
     {
-        foreach (Dependency dependency in sbom.dependencies[0].scored_dependencies)
+        foreach (Dependency dependency in sbom.scored_dependencies)
         {
-            if(dependency.checks is null)
+            if(dependency.dependency_score.checks is null)
             {
                 continue;
             }
-            foreach(Check check in dependency.checks)
+            foreach (Check check in dependency.dependency_score.checks)
             {
+                check.dependency = dependency;
                 if (SbomResult.ContainsKey(check.name))
                 {
                     SbomResult[check.name].Add(check);
@@ -100,6 +140,7 @@ else
                 }
             } 
         }
+        int count = SbomResult.Count;
     }
 
     private async Task PollStatus(SemaphoreSlim pollUntil)
@@ -116,80 +157,76 @@ else
             }
             catch(Exception e)
             {
-              throw(e);  
+                throw(e);  
             }
 
-            
+
             if(statusObj is null)
             {
                 status = "Error";
                 StateHasChanged();
                 return;
             }
-            status = "status!!!:   " + statusObj.ToString();
             StateHasChanged();
         }
 
         StateHasChanged();
     }
 
-    class Sbom
+    public class Sbom
     {
         public string serialNumber { get; set; }
         public int version { get; set; }
         public string repo_name { get; set; }
         public string repo_version { get; set; }
-        public List<DependencyClasses> dependencies { get; set; }
+        public List<Dependency> scored_dependencies { get; set; }
+        public List<Dependency> unscored_dependencies { get; set; }
+        public List<Dependency> failed_dependencies { get; set; }
 
-        public Sbom(string serialNumber, int version, string repo_name, string repo_version, List<DependencyClasses> dependencies)
+        public Sbom(string serialNumber, int version, string repo_name, string repo_version, List<Dependency> scored_dependencies, List<Dependency> unscored_dependencies, List<Dependency> failed_dependencies)
         {
             this.serialNumber = serialNumber;
             this.version = version;
             this.repo_name = repo_name;
             this.repo_version = repo_version;
-            this.dependencies = dependencies;
-        }
-        public override string ToString()
-        {
-            return $"Serial Number: {serialNumber}\nVersion: {version}\nRepo Name: {repo_name}\nRepo Version: {repo_version}\nDependencies: {dependencies[0].ToString()}";
-        }
-    }
-
-    class DependencyClasses
-    {
-        public List<Dependency> scored_dependencies { get; set; }
-        public List<Dependency> unscored_dependencies { get; set; }
-        public List<Dependency> failed_dependencies { get; set; }
-
-        public DependencyClasses(List<Dependency> scored_dependencies, List<Dependency> unscored_dependencies, List<Dependency> failed_dependencies)
-        {
             this.scored_dependencies = scored_dependencies;
             this.unscored_dependencies = unscored_dependencies;
-            this.failed_dependencies = failed_dependencies; 
+            this.failed_dependencies = failed_dependencies;
         }
         public override string ToString()
         {
-            return $"Scored Dependencies: {scored_dependencies.ToString()}\nUnscored Dependencies: {unscored_dependencies.ToString()}\nFailed Dependencies: {failed_dependencies.ToString()}";
+            return $"Serial Number: {serialNumber}\nVersion: {version}\nRepo Name: {repo_name}\nRepo Version: {repo_version}\n";
+        }
+    }
+    public class Dependency
+    {
+        public string name { get; set; }
+        public string version { get; set; }
+        public DependencyScore dependency_score { get; set; }
+
+        public Dependency(string name, string version, DependencyScore dependency_score)
+        {
+            this.name = name;
+            this.version = version;
+            this.dependency_score = dependency_score;
         }
     }
 
-    class Dependency
+    public class DependencyScore
     {
         public string date { get; set; }
-        public string version { get; set; }
         public float score { get; set; }
         public List<Check> checks { get; set; }
 
-        public Dependency(string date, string version, float score, List<Check> checks)
+        public DependencyScore(string date, float score, List<Check> checks)
         {
             this.date = date;
-            this.version = version;
             this.score = score;
             this. checks = checks;
         }
         public override string ToString()
         {
-            return $"Date: {date}\nVersion: {version}\nScore: {score}\nChecks: {checks.ToString()}";
+            return $"Date: {date}\nScore: {score}\nChecks: {checks.ToString()}";
         }
     }
     public class Check
@@ -197,9 +234,10 @@ else
         public string name { get; set; }
         public int score { get; set; }
         public string reason { get; set; }
-        public string details { get; set; }
+        public List<string> details { get; set; }
+        public Dependency dependency { get; set; }
 
-        public Check(string name, int score, string reason, string details)
+        public Check(string name, int score, string reason, List<string> details)
         {
             this.name = name;
             this.score = score;
@@ -212,7 +250,7 @@ else
         }
     }
 
-    class Status
+    public class Status
     {
         public string current_state { get; set; }
         public StepResponse step_response { get; set; }
@@ -224,10 +262,14 @@ else
         }
         public override string ToString()
         {
+            if(step_response is null)
+            {
+                return $"{current_state}";
+            }
             return $"{current_state}    {step_response.ToString()}";
         }
     }
-    class StepResponse
+    public class StepResponse
     {
         public int batch_size { get; set; }
         public int completed_items { get; set; }

--- a/src/frontend/OSSQAWebAPI/OSSQAWebAPI/Components/Pages/SbomAnalysis.razor
+++ b/src/frontend/OSSQAWebAPI/OSSQAWebAPI/Components/Pages/SbomAnalysis.razor
@@ -1,5 +1,4 @@
-﻿
-@using System.Diagnostics
+﻿@using System.Diagnostics
 @inject HttpClient Http
 @inject HttpClient httpClient
 @using System.Text.Json
@@ -11,66 +10,79 @@
 
 
 
-@if(statusObj is not null)
+@if (statusObj is not null)
 {
-    if(statusObj.step_response is not null)
+    if (statusObj.step_response is not null)
     {
         <div class="d-flex flex-column align-items-center justify-content-center">
-            <h1>@statusObj.current_state</h1>
-            <h2>@statusObj.step_response.message</h2>
-            <h3>Batch Size: @statusObj.step_response.batch_size</h3>
-            <h3>Completed Items: @statusObj.step_response.completed_items</h3>
-            <h3>Successful Items: @statusObj.step_response.successful_items</h3>
-            <h3>Failed Items: @statusObj.step_response.failed_items</h3>
+            <h3>@statusObj.current_state</h3>
+            <h3>@statusObj.step_response.message</h3>
+            <h5>Batch Size: @statusObj.step_response.batch_size</h5>
+            <h5>Completed Items: @statusObj.step_response.completed_items</h5>
+            <h5>Successful Items: @statusObj.step_response.successful_items</h5>
+            <h5>Failed Items: @statusObj.step_response.failed_items</h5>
+        </div>
+    }
+    else
+    {
+        <div class="d-flex flex-column align-items-center justify-content-center">
+            <h3>@statusObj.current_state</h3>
         </div>
     }
 }
 
-else
+@if (Analyzing.CurrentCount == 0)
 {
-    <div class="d-flex flex-column align-items-center justify-content-center">
-        <h1>Waiting for analysis to complete</h1>
-    </div>
-}
 
-@if(Analyzing.CurrentCount == 0)
-{
-    
     <div class="d-flex flex-column align-items-center justify-content-center">
         <MatProgressCircle Indeterminate="true" Size="MatProgressCircleSize.Medium" />
     </div>
 }
 else
 {
-    <div class="d-flex flex-column align-items-center justify-content-center">     
+    <div class="d-flex flex-column align-items-center justify-content-center">
         <MatButton OnClick='()=> _navigationManager.NavigateTo("/", true)'> Analyze another SBOM</MatButton>
     </div>
 }
-<p>@fullSBOM</p>
+<div class="d-flex flex-column align-items-center justify-content-center">
+    <div class="d-flex flex-column">
+        @if (FailedDependencies is not null && FailedDependencies.Count > 0)
+        {
+            <h5>Failed Items</h5>
+            @foreach (var failedDependency in FailedDependencies)
+            {
+                string url = "https://" + failedDependency.name;
+                <p>Repo: <a href="@url"> @failedDependency.name</a></p>
+                <p>Reason: @failedDependency.failure_reason</p>
 
-
-
+            }
+        }
+    </div>
+</div>
 
 
 @code {
     private float score = 0;
     Dictionary<string, string> statusInfo = new();
-    string status = "hej baby";
+    string status = "";
     private string fullSBOM = "";
-    private Status statusObj ;
+    private Status statusObj;
+    Sbom sbom;
     [Parameter]
     public SemaphoreSlim Analyzing { get; set; }
     [Parameter]
     public Dictionary<string, List<Check>> SbomResult { get; set; }
     [Parameter]
-    public Dictionary<string, string> PostData { get; set;}
+    public Dictionary<string, string> PostData { get; set; }
     [Parameter]
     public Action StateHasChangedCallback { get; set; }
+    [Parameter]
+    public List<SbomAnalysis.Dependency> FailedDependencies { get; set; }
     protected override void OnInitialized()
     {
         Analyze();
     }
-    private async Task Analyze()
+    private void Analyze()
     {
         var analyzeTask = Http.PostAsJsonAsync("http://host.docker.internal:98/analyze", PostData);
 
@@ -87,8 +99,9 @@ else
 
                 try
                 {
-                    Sbom sbom = JsonSerializer.Deserialize<Sbom>(SBOMString);
+                    sbom = JsonSerializer.Deserialize<Sbom>(SBOMString);
                     AddToDict(sbom);
+                    AddFailed(sbom);
 
                 }
                 catch (Exception e)
@@ -96,16 +109,17 @@ else
                     throw (e);
                 }
                 StateHasChangedCallback.Invoke();
-                StateHasChanged();
+                _ = InvokeAsync(StateHasChanged);
             }
         });
         _ = PollStatus(Analyzing);
     }
+
     private void AddToDict(Sbom sbom)
     {
         foreach (Dependency dependency in sbom.scored_dependencies)
         {
-            if(dependency.dependency_score.checks is null)
+            if (dependency.dependency_score.checks is null)
             {
                 continue;
             }
@@ -120,39 +134,38 @@ else
                 {
                     SbomResult.Add(check.name, new List<Check> { check });
                 }
-            } 
+            }
         }
         int count = SbomResult.Count;
     }
 
+    private void AddFailed(Sbom sbom)
+    {
+        foreach (Dependency dependency in sbom.failed_dependencies)
+        {
+            FailedDependencies.Add(dependency);
+        }
+    }
+
     private async Task PollStatus(SemaphoreSlim pollUntil)
     {
-
         while (pollUntil.CurrentCount == 0)
         {
-            await Task.Delay(1000);
+            await Task.Delay(500);
             HttpResponseMessage response = await Http.GetAsync("http://host.docker.internal:98/get_current_status");
             string responseString = await response.Content.ReadAsStringAsync();
+            status = responseString;
             try
             {
                 statusObj = JsonSerializer.Deserialize<Status>(responseString);
             }
-            catch(Exception e)
+            catch (Exception e)
             {
-                throw(e);
+                throw (e);
             }
-
-
-            if(statusObj is null)
-            {
-                status = "Error";
-                StateHasChanged();
-                return;
-            }
-            StateHasChanged();
+            _ = InvokeAsync(StateHasChanged);
         }
-
-        StateHasChanged();
+        _ = InvokeAsync(StateHasChanged);
     }
 
     public class Sbom
@@ -180,17 +193,20 @@ else
             return $"Serial Number: {serialNumber}\nVersion: {version}\nRepo Name: {repo_name}\nRepo Version: {repo_version}\n";
         }
     }
+
     public class Dependency
     {
         public string name { get; set; }
         public string version { get; set; }
         public DependencyScore dependency_score { get; set; }
+        public string failure_reason { get; set; }
 
-        public Dependency(string name, string version, DependencyScore dependency_score)
+        public Dependency(string name, string version, DependencyScore dependency_score, string failure_reason)
         {
             this.name = name;
             this.version = version;
             this.dependency_score = dependency_score;
+            this.failure_reason = failure_reason;
         }
     }
 
@@ -204,13 +220,14 @@ else
         {
             this.date = date;
             this.score = score;
-            this. checks = checks;
+            this.checks = checks;
         }
         public override string ToString()
         {
             return $"Date: {date}\nScore: {score}\nChecks: {checks.ToString()}";
         }
     }
+
     public class Check
     {
         public string name { get; set; }
@@ -232,6 +249,22 @@ else
         }
     }
 
+    public class FailedDependency
+    {
+        public string name { get; set; }
+        public string version { get; set; }
+        public string dependency_score { get; set; }
+        public string failure_reason { get; set; }
+
+        public FailedDependency(string name, string version, string dependency_score, string failure_reason)
+        {
+            this.name = name;
+            this.version = version;
+            this.dependency_score = dependency_score;
+            this.failure_reason = failure_reason;
+        }
+    }
+
     public class Status
     {
         public string current_state { get; set; }
@@ -244,13 +277,14 @@ else
         }
         public override string ToString()
         {
-            if(step_response is null)
+            if (step_response is null)
             {
                 return $"{current_state}";
             }
             return $"{current_state}    {step_response.ToString()}";
         }
     }
+
     public class StepResponse
     {
         public int batch_size { get; set; }

--- a/src/frontend/OSSQAWebAPI/OSSQAWebAPI/Components/Pages/SpecifyReqs.razor
+++ b/src/frontend/OSSQAWebAPI/OSSQAWebAPI/Components/Pages/SpecifyReqs.razor
@@ -1,4 +1,8 @@
 ﻿@using System.Text.Json
+
+@* this component handles user requirement inputs*@
+
+
 <ViewLogo />
 <div class="d-flex justify-content-center align-items-center flex-column">
     <h2 style="margin-bottom:1em;">Specify requirement weights</h2>
@@ -14,6 +18,9 @@
     }
     <MatButton Raised="true" Style="font-size:1.5em; width:20vw;margin-top:2em;" @onclick="()=>{ValidateReqs();}">Analyze</MatButton>
 </div>
+
+
+
 
 @code {
     [Parameter]

--- a/src/frontend/OSSQAWebAPI/OSSQAWebAPI/Components/Pages/ViewLogo.razor
+++ b/src/frontend/OSSQAWebAPI/OSSQAWebAPI/Components/Pages/ViewLogo.razor
@@ -1,4 +1,6 @@
-﻿<div class="d-flex justify-content-center flex-column align-items-center m-5">
+﻿@* this component displays the logo*@
+
+<div class="d-flex justify-content-center flex-column align-items-center m-5">
     <img src="/images/LOGO_OSSQA.png" asp-append-version="true" width="250px" />
 
 </div>

--- a/src/frontend/OSSQAWebAPI/OSSQAWebAPI/Components/Pages/ViewResults.razor
+++ b/src/frontend/OSSQAWebAPI/OSSQAWebAPI/Components/Pages/ViewResults.razor
@@ -15,7 +15,11 @@
                     values.Sort((x, y) => x.score.CompareTo(y.score));
                     foreach (var check in values)
                     {
-                        <p>Score: @check.score/10</p>
+                        if(check.dependency.name != null)
+                        {
+                            var url = $"https://{check.dependency.name}";
+                            <p>Score: @check.score/10 URL: <a href="@url">@check.dependency.name</a> </p>
+                        }
                     }
                 }
             </div>

--- a/src/frontend/OSSQAWebAPI/OSSQAWebAPI/Components/Pages/ViewResults.razor
+++ b/src/frontend/OSSQAWebAPI/OSSQAWebAPI/Components/Pages/ViewResults.razor
@@ -1,3 +1,5 @@
+@* This component generates result for each category tab*@
+
 <div class="d-flex">
     <a href="https://securityscorecards.dev/#the-checks" style="margin-top:3em; margin-bottom:2em;"> What do these results mean?</a>
 </div>

--- a/src/frontend/OSSQAWebAPI/OSSQAWebAPI/Program.cs
+++ b/src/frontend/OSSQAWebAPI/OSSQAWebAPI/Program.cs
@@ -1,4 +1,3 @@
-using Microsoft.AspNetCore.Components;
 using OSSQAWebAPI.Components;
 public class Program
 {

--- a/src/frontend/test_result.json
+++ b/src/frontend/test_result.json
@@ -1,0 +1,2224 @@
+{
+   "serialNumber":"urn:uuid:d7a0ac67-e0f8-4342-86c6-801a02437636",
+   "version":1,
+   "repo_name":"github.com/ossf/scorecard",
+   "repo_version":"v1.8.0",
+    "scored_dependencies":[
+    {
+        "name":"github.com/allan-simon/go-singleinstance",
+        "version":"v0.0.0-20160830203053-79edcfdc2dfc",
+        "dependency_score":{
+            "date": "2024-03-18",
+            "score": 7.1,
+            "checks": [
+                {
+                    "name": "Binary-Artifacts",
+                    "score": 10,
+                    "reason": "no binaries found in the repo",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has generated executable (binary) artifacts in the source repository.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#binary-artifacts"
+                    }
+                },
+                {
+                    "name": "Branch-Protection",
+                    "score": -1,
+                    "reason": "internal error: error during branchesHandler.setup: internal error: githubv4.Query: Resource not accessible by integration",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the default and release branches are protected with GitHub's branch protection settings.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#branch-protection"
+                    }
+                },
+                {
+                    "name": "CI-Tests",
+                    "score": 10,
+                    "reason": "22 out of 22 merged PRs checked by a CI test -- score normalized to 10",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project runs tests before pull requests are merged.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#ci-tests"
+                    }
+                },
+                {
+                    "name": "CII-Best-Practices",
+                    "score": 0,
+                    "reason": "no badge detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has an OpenSSF (formerly CII) Best Practices Badge.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#cii-best-practices"
+                    }
+                },
+                {
+                    "name": "Code-Review",
+                    "score": 10,
+                    "reason": "22 out of last 22 changesets reviewed before merge -- score normalized to 10",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project requires code review before pull requests (aka merge requests) are merged.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#code-review"
+                    }
+                },
+                {
+                    "name": "Contributors",
+                    "score": 10,
+                    "reason": "39 different organizations found -- score normalized to 10",
+                    "details": [
+                        "Info: contributors work for BreizhJUG,Dockins,FyneHeroes,WP-Team-Bach,allons-y,amontourdeprogrammer,anonaddy,atlassian,breizhcamp,chad metcalf,ci-reporter,cnabio,compose-spec,containerd,daytonaio,degreed,depcheck,distribution,docker,docker-archive,docker-captains,dockersamples,docsorg,focus-on-systems,full city tech co.,github-beta,go-docker,goreleaser,jnr,jruby,librenms,magefile,maintainers,moby,neard,opencontainers,portapps,thajeztah,tilt-dev"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project has a set of contributors from multiple organizations (e.g., companies).",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#contributors"
+                    }
+                },
+                {
+                    "name": "Dangerous-Workflow",
+                    "score": 10,
+                    "reason": "no dangerous workflow patterns detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project's GitHub Action workflows avoid dangerous patterns.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#dangerous-workflow"
+                    }
+                },
+                {
+                    "name": "Dependency-Update-Tool",
+                    "score": 10,
+                    "reason": "update tool detected",
+                    "details": [
+                        "Info: Dependabot detected: .github/dependabot.yml:1"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project uses a dependency update tool.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#dependency-update-tool"
+                    }
+                },
+                {
+                    "name": "Fuzzing",
+                    "score": -1,
+                    "reason": "internal error: internal error: Client.Search.Code: Search.Code: GET https://api.github.com/search/code?q=github.com+docker+compose+repo%3Agoogle%2Foss-fuzz+in%3Afile+filename%3Aproject.yaml: 403 You have exceeded a secondary rate limit. Please wait a few minutes before you try again. If you reach out to GitHub Support for help, please include the request ID 5858:8923:4BF59:90008:65F859D0. []",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project uses fuzzing.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#fuzzing"
+                    }
+                },
+                {
+                    "name": "License",
+                    "score": 10,
+                    "reason": "license file detected",
+                    "details": [
+                        "Info: : LICENSE:1"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project has defined a license.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#license"
+                    }
+                },
+                {
+                    "name": "Maintained",
+                    "score": 10,
+                    "reason": "30 commit(s) out of 30 and 1 issue activity out of 30 found in the last 90 days -- score normalized to 10",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project is \"actively maintained\".",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#maintained"
+                    }
+                },
+                {
+                    "name": "Packaging",
+                    "score": -1,
+                    "reason": "no published package detected",
+                    "details": [
+                        "Warn: no GitHub publishing workflow detected"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project is published as a package that others can easily download, install, easily update, and uninstall.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#packaging"
+                    }
+                },
+                {
+                    "name": "Pinned-Dependencies",
+                    "score": -1,
+                    "reason": "internal error: error parsing shell code: Dockerfile:1:1: unclosed here-document 'EOT'",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has declared and pinned the dependencies of its build process.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#pinned-dependencies"
+                    }
+                },
+                {
+                    "name": "SAST",
+                    "score": -1,
+                    "reason": "internal error: Client.Search.Code: Search.Code: GET https://api.github.com/search/code?q=github+codeql-action+analyze+repo%3Adocker%2Fcompose+path%3A%2F.github%2Fworkflows: 403 You have exceeded a secondary rate limit. Please wait a few minutes before you try again. If you reach out to GitHub Support for help, please include the request ID 5858:8923:4BF0C:8FF6D:65F859CF. []",
+                    "details": [
+                        "Warn: 0 commits out of 30 are checked with a SAST tool"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project uses static code analysis.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#sast"
+                    }
+                },
+                {
+                    "name": "Security-Policy",
+                    "score": 0,
+                    "reason": "security policy file not detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has published a security policy.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#security-policy"
+                    }
+                },
+                {
+                    "name": "Signed-Releases",
+                    "score": 0,
+                    "reason": "0 out of 5 artifacts are signed or have provenance",
+                    "details": [
+                        "Warn: release artifact v2.25.0 does not have provenance: https://api.github.com/repos/docker/compose/releases/146766600",
+                        "Warn: release artifact v2.25.0 not signed: https://api.github.com/repos/docker/compose/releases/146766600",
+                        "Warn: release artifact v2.24.7 does not have provenance: https://api.github.com/repos/docker/compose/releases/144954606",
+                        "Warn: release artifact v2.24.7 not signed: https://api.github.com/repos/docker/compose/releases/144954606",
+                        "Warn: release artifact v2.24.6 does not have provenance: https://api.github.com/repos/docker/compose/releases/142153265",
+                        "Warn: release artifact v2.24.6 not signed: https://api.github.com/repos/docker/compose/releases/142153265",
+                        "Warn: release artifact v2.24.5 does not have provenance: https://api.github.com/repos/docker/compose/releases/139179155",
+                        "Warn: release artifact v2.24.5 not signed: https://api.github.com/repos/docker/compose/releases/139179155",
+                        "Warn: release artifact v2.24.4 does not have provenance: https://api.github.com/repos/docker/compose/releases/139010398",
+                        "Warn: release artifact v2.24.4 not signed: https://api.github.com/repos/docker/compose/releases/139010398"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project cryptographically signs release artifacts.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#signed-releases"
+                    }
+                },
+                {
+                    "name": "Token-Permissions",
+                    "score": 0,
+                    "reason": "non read-only tokens detected in GitHub workflows",
+                    "details": [
+                        "Info: topLevel 'contents' permission set to 'read': .github/workflows/ci.yml:25: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/ci.yml/main?enable=permissions",
+                        "Warn: jobLevel 'contents' permission set to 'write': .github/workflows/ci.yml:256: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/ci.yml/main?enable=permissions",
+                        "Warn: no topLevel permission defined: .github/workflows/codeql.yml:1: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/codeql.yml/main?enable=permissions",
+                        "Info: jobLevel 'actions' permission set to 'read': .github/workflows/codeql.yml:26: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/codeql.yml/main?enable=permissions",
+                        "Info: jobLevel 'contents' permission set to 'read': .github/workflows/codeql.yml:27: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/codeql.yml/main?enable=permissions",
+                        "Warn: no topLevel permission defined: .github/workflows/docs-upstream.yml:1: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/docs-upstream.yml/main?enable=permissions",
+                        "Info: topLevel 'contents' permission set to 'read': .github/workflows/merge.yml:15: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/merge.yml/main?enable=permissions",
+                        "Info: topLevel permissions set to 'read-all': .github/workflows/scorecards.yml:11: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/scorecards.yml/main?enable=permissions"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project's workflows follow the principle of least privilege.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#token-permissions"
+                    }
+                },
+                {
+                    "name": "Vulnerabilities",
+                    "score": 10,
+                    "reason": "no vulnerabilities detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has open, known unfixed vulnerabilities.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#vulnerabilities"
+                    }
+                }
+            ]
+        },
+        "failure_reason":""
+    },
+    {
+        "name":"github.com/andybalholm/cascadia",
+        "version":"v1.1.0",
+        "dependency_score":{
+            "date": "2024-03-18",
+            "score": 7.1,
+            "checks": [
+                {
+                    "name": "Binary-Artifacts",
+                    "score": 10,
+                    "reason": "no binaries found in the repo",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has generated executable (binary) artifacts in the source repository.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#binary-artifacts"
+                    }
+                },
+                {
+                    "name": "Branch-Protection",
+                    "score": -1,
+                    "reason": "internal error: error during branchesHandler.setup: internal error: githubv4.Query: Resource not accessible by integration",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the default and release branches are protected with GitHub's branch protection settings.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#branch-protection"
+                    }
+                },
+                {
+                    "name": "CI-Tests",
+                    "score": 10,
+                    "reason": "22 out of 22 merged PRs checked by a CI test -- score normalized to 10",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project runs tests before pull requests are merged.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#ci-tests"
+                    }
+                },
+                {
+                    "name": "CII-Best-Practices",
+                    "score": 0,
+                    "reason": "no badge detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has an OpenSSF (formerly CII) Best Practices Badge.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#cii-best-practices"
+                    }
+                },
+                {
+                    "name": "Code-Review",
+                    "score": 10,
+                    "reason": "22 out of last 22 changesets reviewed before merge -- score normalized to 10",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project requires code review before pull requests (aka merge requests) are merged.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#code-review"
+                    }
+                },
+                {
+                    "name": "Contributors",
+                    "score": 10,
+                    "reason": "39 different organizations found -- score normalized to 10",
+                    "details": [
+                        "Info: contributors work for BreizhJUG,Dockins,FyneHeroes,WP-Team-Bach,allons-y,amontourdeprogrammer,anonaddy,atlassian,breizhcamp,chad metcalf,ci-reporter,cnabio,compose-spec,containerd,daytonaio,degreed,depcheck,distribution,docker,docker-archive,docker-captains,dockersamples,docsorg,focus-on-systems,full city tech co.,github-beta,go-docker,goreleaser,jnr,jruby,librenms,magefile,maintainers,moby,neard,opencontainers,portapps,thajeztah,tilt-dev"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project has a set of contributors from multiple organizations (e.g., companies).",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#contributors"
+                    }
+                },
+                {
+                    "name": "Dangerous-Workflow",
+                    "score": 10,
+                    "reason": "no dangerous workflow patterns detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project's GitHub Action workflows avoid dangerous patterns.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#dangerous-workflow"
+                    }
+                },
+                {
+                    "name": "Dependency-Update-Tool",
+                    "score": 10,
+                    "reason": "update tool detected",
+                    "details": [
+                        "Info: Dependabot detected: .github/dependabot.yml:1"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project uses a dependency update tool.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#dependency-update-tool"
+                    }
+                },
+                {
+                    "name": "Fuzzing",
+                    "score": -1,
+                    "reason": "internal error: internal error: Client.Search.Code: Search.Code: GET https://api.github.com/search/code?q=github.com+docker+compose+repo%3Agoogle%2Foss-fuzz+in%3Afile+filename%3Aproject.yaml: 403 You have exceeded a secondary rate limit. Please wait a few minutes before you try again. If you reach out to GitHub Support for help, please include the request ID 5858:8923:4BF59:90008:65F859D0. []",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project uses fuzzing.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#fuzzing"
+                    }
+                },
+                {
+                    "name": "License",
+                    "score": 10,
+                    "reason": "license file detected",
+                    "details": [
+                        "Info: : LICENSE:1"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project has defined a license.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#license"
+                    }
+                },
+                {
+                    "name": "Maintained",
+                    "score": 10,
+                    "reason": "30 commit(s) out of 30 and 1 issue activity out of 30 found in the last 90 days -- score normalized to 10",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project is \"actively maintained\".",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#maintained"
+                    }
+                },
+                {
+                    "name": "Packaging",
+                    "score": -1,
+                    "reason": "no published package detected",
+                    "details": [
+                        "Warn: no GitHub publishing workflow detected"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project is published as a package that others can easily download, install, easily update, and uninstall.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#packaging"
+                    }
+                },
+                {
+                    "name": "Pinned-Dependencies",
+                    "score": -1,
+                    "reason": "internal error: error parsing shell code: Dockerfile:1:1: unclosed here-document 'EOT'",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has declared and pinned the dependencies of its build process.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#pinned-dependencies"
+                    }
+                },
+                {
+                    "name": "SAST",
+                    "score": -1,
+                    "reason": "internal error: Client.Search.Code: Search.Code: GET https://api.github.com/search/code?q=github+codeql-action+analyze+repo%3Adocker%2Fcompose+path%3A%2F.github%2Fworkflows: 403 You have exceeded a secondary rate limit. Please wait a few minutes before you try again. If you reach out to GitHub Support for help, please include the request ID 5858:8923:4BF0C:8FF6D:65F859CF. []",
+                    "details": [
+                        "Warn: 0 commits out of 30 are checked with a SAST tool"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project uses static code analysis.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#sast"
+                    }
+                },
+                {
+                    "name": "Security-Policy",
+                    "score": 0,
+                    "reason": "security policy file not detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has published a security policy.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#security-policy"
+                    }
+                },
+                {
+                    "name": "Signed-Releases",
+                    "score": 0,
+                    "reason": "0 out of 5 artifacts are signed or have provenance",
+                    "details": [
+                        "Warn: release artifact v2.25.0 does not have provenance: https://api.github.com/repos/docker/compose/releases/146766600",
+                        "Warn: release artifact v2.25.0 not signed: https://api.github.com/repos/docker/compose/releases/146766600",
+                        "Warn: release artifact v2.24.7 does not have provenance: https://api.github.com/repos/docker/compose/releases/144954606",
+                        "Warn: release artifact v2.24.7 not signed: https://api.github.com/repos/docker/compose/releases/144954606",
+                        "Warn: release artifact v2.24.6 does not have provenance: https://api.github.com/repos/docker/compose/releases/142153265",
+                        "Warn: release artifact v2.24.6 not signed: https://api.github.com/repos/docker/compose/releases/142153265",
+                        "Warn: release artifact v2.24.5 does not have provenance: https://api.github.com/repos/docker/compose/releases/139179155",
+                        "Warn: release artifact v2.24.5 not signed: https://api.github.com/repos/docker/compose/releases/139179155",
+                        "Warn: release artifact v2.24.4 does not have provenance: https://api.github.com/repos/docker/compose/releases/139010398",
+                        "Warn: release artifact v2.24.4 not signed: https://api.github.com/repos/docker/compose/releases/139010398"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project cryptographically signs release artifacts.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#signed-releases"
+                    }
+                },
+                {
+                    "name": "Token-Permissions",
+                    "score": 0,
+                    "reason": "non read-only tokens detected in GitHub workflows",
+                    "details": [
+                        "Info: topLevel 'contents' permission set to 'read': .github/workflows/ci.yml:25: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/ci.yml/main?enable=permissions",
+                        "Warn: jobLevel 'contents' permission set to 'write': .github/workflows/ci.yml:256: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/ci.yml/main?enable=permissions",
+                        "Warn: no topLevel permission defined: .github/workflows/codeql.yml:1: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/codeql.yml/main?enable=permissions",
+                        "Info: jobLevel 'actions' permission set to 'read': .github/workflows/codeql.yml:26: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/codeql.yml/main?enable=permissions",
+                        "Info: jobLevel 'contents' permission set to 'read': .github/workflows/codeql.yml:27: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/codeql.yml/main?enable=permissions",
+                        "Warn: no topLevel permission defined: .github/workflows/docs-upstream.yml:1: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/docs-upstream.yml/main?enable=permissions",
+                        "Info: topLevel 'contents' permission set to 'read': .github/workflows/merge.yml:15: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/merge.yml/main?enable=permissions",
+                        "Info: topLevel permissions set to 'read-all': .github/workflows/scorecards.yml:11: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/scorecards.yml/main?enable=permissions"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project's workflows follow the principle of least privilege.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#token-permissions"
+                    }
+                },
+                {
+                    "name": "Vulnerabilities",
+                    "score": 10,
+                    "reason": "no vulnerabilities detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has open, known unfixed vulnerabilities.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#vulnerabilities"
+                    }
+                }
+            ]
+        },
+        "failure_reason":""
+    },
+    {
+        "name":"github.com/antlr/antlr4",
+        "version":"v0.0.0-20201029161626-9a95f0cc3d7c",
+        "dependency_score":{
+            "date": "2024-03-18",
+            "score": 7.1,
+            "checks": [
+                {
+                    "name": "Binary-Artifacts",
+                    "score": 10,
+                    "reason": "no binaries found in the repo",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has generated executable (binary) artifacts in the source repository.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#binary-artifacts"
+                    }
+                },
+                {
+                    "name": "Branch-Protection",
+                    "score": -1,
+                    "reason": "internal error: error during branchesHandler.setup: internal error: githubv4.Query: Resource not accessible by integration",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the default and release branches are protected with GitHub's branch protection settings.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#branch-protection"
+                    }
+                },
+                {
+                    "name": "CI-Tests",
+                    "score": 10,
+                    "reason": "22 out of 22 merged PRs checked by a CI test -- score normalized to 10",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project runs tests before pull requests are merged.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#ci-tests"
+                    }
+                },
+                {
+                    "name": "CII-Best-Practices",
+                    "score": 0,
+                    "reason": "no badge detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has an OpenSSF (formerly CII) Best Practices Badge.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#cii-best-practices"
+                    }
+                },
+                {
+                    "name": "Code-Review",
+                    "score": 10,
+                    "reason": "22 out of last 22 changesets reviewed before merge -- score normalized to 10",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project requires code review before pull requests (aka merge requests) are merged.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#code-review"
+                    }
+                },
+                {
+                    "name": "Contributors",
+                    "score": 10,
+                    "reason": "39 different organizations found -- score normalized to 10",
+                    "details": [
+                        "Info: contributors work for BreizhJUG,Dockins,FyneHeroes,WP-Team-Bach,allons-y,amontourdeprogrammer,anonaddy,atlassian,breizhcamp,chad metcalf,ci-reporter,cnabio,compose-spec,containerd,daytonaio,degreed,depcheck,distribution,docker,docker-archive,docker-captains,dockersamples,docsorg,focus-on-systems,full city tech co.,github-beta,go-docker,goreleaser,jnr,jruby,librenms,magefile,maintainers,moby,neard,opencontainers,portapps,thajeztah,tilt-dev"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project has a set of contributors from multiple organizations (e.g., companies).",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#contributors"
+                    }
+                },
+                {
+                    "name": "Dangerous-Workflow",
+                    "score": 10,
+                    "reason": "no dangerous workflow patterns detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project's GitHub Action workflows avoid dangerous patterns.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#dangerous-workflow"
+                    }
+                },
+                {
+                    "name": "Dependency-Update-Tool",
+                    "score": 10,
+                    "reason": "update tool detected",
+                    "details": [
+                        "Info: Dependabot detected: .github/dependabot.yml:1"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project uses a dependency update tool.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#dependency-update-tool"
+                    }
+                },
+                {
+                    "name": "Fuzzing",
+                    "score": -1,
+                    "reason": "internal error: internal error: Client.Search.Code: Search.Code: GET https://api.github.com/search/code?q=github.com+docker+compose+repo%3Agoogle%2Foss-fuzz+in%3Afile+filename%3Aproject.yaml: 403 You have exceeded a secondary rate limit. Please wait a few minutes before you try again. If you reach out to GitHub Support for help, please include the request ID 5858:8923:4BF59:90008:65F859D0. []",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project uses fuzzing.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#fuzzing"
+                    }
+                },
+                {
+                    "name": "License",
+                    "score": 10,
+                    "reason": "license file detected",
+                    "details": [
+                        "Info: : LICENSE:1"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project has defined a license.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#license"
+                    }
+                },
+                {
+                    "name": "Maintained",
+                    "score": 10,
+                    "reason": "30 commit(s) out of 30 and 1 issue activity out of 30 found in the last 90 days -- score normalized to 10",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project is \"actively maintained\".",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#maintained"
+                    }
+                },
+                {
+                    "name": "Packaging",
+                    "score": -1,
+                    "reason": "no published package detected",
+                    "details": [
+                        "Warn: no GitHub publishing workflow detected"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project is published as a package that others can easily download, install, easily update, and uninstall.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#packaging"
+                    }
+                },
+                {
+                    "name": "Pinned-Dependencies",
+                    "score": -1,
+                    "reason": "internal error: error parsing shell code: Dockerfile:1:1: unclosed here-document 'EOT'",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has declared and pinned the dependencies of its build process.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#pinned-dependencies"
+                    }
+                },
+                {
+                    "name": "SAST",
+                    "score": -1,
+                    "reason": "internal error: Client.Search.Code: Search.Code: GET https://api.github.com/search/code?q=github+codeql-action+analyze+repo%3Adocker%2Fcompose+path%3A%2F.github%2Fworkflows: 403 You have exceeded a secondary rate limit. Please wait a few minutes before you try again. If you reach out to GitHub Support for help, please include the request ID 5858:8923:4BF0C:8FF6D:65F859CF. []",
+                    "details": [
+                        "Warn: 0 commits out of 30 are checked with a SAST tool"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project uses static code analysis.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#sast"
+                    }
+                },
+                {
+                    "name": "Security-Policy",
+                    "score": 0,
+                    "reason": "security policy file not detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has published a security policy.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#security-policy"
+                    }
+                },
+                {
+                    "name": "Signed-Releases",
+                    "score": 0,
+                    "reason": "0 out of 5 artifacts are signed or have provenance",
+                    "details": [
+                        "Warn: release artifact v2.25.0 does not have provenance: https://api.github.com/repos/docker/compose/releases/146766600",
+                        "Warn: release artifact v2.25.0 not signed: https://api.github.com/repos/docker/compose/releases/146766600",
+                        "Warn: release artifact v2.24.7 does not have provenance: https://api.github.com/repos/docker/compose/releases/144954606",
+                        "Warn: release artifact v2.24.7 not signed: https://api.github.com/repos/docker/compose/releases/144954606",
+                        "Warn: release artifact v2.24.6 does not have provenance: https://api.github.com/repos/docker/compose/releases/142153265",
+                        "Warn: release artifact v2.24.6 not signed: https://api.github.com/repos/docker/compose/releases/142153265",
+                        "Warn: release artifact v2.24.5 does not have provenance: https://api.github.com/repos/docker/compose/releases/139179155",
+                        "Warn: release artifact v2.24.5 not signed: https://api.github.com/repos/docker/compose/releases/139179155",
+                        "Warn: release artifact v2.24.4 does not have provenance: https://api.github.com/repos/docker/compose/releases/139010398",
+                        "Warn: release artifact v2.24.4 not signed: https://api.github.com/repos/docker/compose/releases/139010398"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project cryptographically signs release artifacts.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#signed-releases"
+                    }
+                },
+                {
+                    "name": "Token-Permissions",
+                    "score": 0,
+                    "reason": "non read-only tokens detected in GitHub workflows",
+                    "details": [
+                        "Info: topLevel 'contents' permission set to 'read': .github/workflows/ci.yml:25: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/ci.yml/main?enable=permissions",
+                        "Warn: jobLevel 'contents' permission set to 'write': .github/workflows/ci.yml:256: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/ci.yml/main?enable=permissions",
+                        "Warn: no topLevel permission defined: .github/workflows/codeql.yml:1: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/codeql.yml/main?enable=permissions",
+                        "Info: jobLevel 'actions' permission set to 'read': .github/workflows/codeql.yml:26: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/codeql.yml/main?enable=permissions",
+                        "Info: jobLevel 'contents' permission set to 'read': .github/workflows/codeql.yml:27: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/codeql.yml/main?enable=permissions",
+                        "Warn: no topLevel permission defined: .github/workflows/docs-upstream.yml:1: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/docs-upstream.yml/main?enable=permissions",
+                        "Info: topLevel 'contents' permission set to 'read': .github/workflows/merge.yml:15: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/merge.yml/main?enable=permissions",
+                        "Info: topLevel permissions set to 'read-all': .github/workflows/scorecards.yml:11: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/scorecards.yml/main?enable=permissions"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project's workflows follow the principle of least privilege.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#token-permissions"
+                    }
+                },
+                {
+                    "name": "Vulnerabilities",
+                    "score": 10,
+                    "reason": "no vulnerabilities detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has open, known unfixed vulnerabilities.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#vulnerabilities"
+                    }
+                }
+            ]
+        },
+        "failure_reason":""
+    },
+    {
+        "name":"github.com/armon/consul-api",
+        "version":"v0.0.0-20180202201655-eb2c6b5be1b6",
+        "dependency_score":{
+            "date": "2024-03-18",
+            "score": 7.1,
+            "checks": [
+                {
+                    "name": "Binary-Artifacts",
+                    "score": 10,
+                    "reason": "no binaries found in the repo",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has generated executable (binary) artifacts in the source repository.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#binary-artifacts"
+                    }
+                },
+                {
+                    "name": "Branch-Protection",
+                    "score": -1,
+                    "reason": "internal error: error during branchesHandler.setup: internal error: githubv4.Query: Resource not accessible by integration",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the default and release branches are protected with GitHub's branch protection settings.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#branch-protection"
+                    }
+                },
+                {
+                    "name": "CI-Tests",
+                    "score": 10,
+                    "reason": "22 out of 22 merged PRs checked by a CI test -- score normalized to 10",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project runs tests before pull requests are merged.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#ci-tests"
+                    }
+                },
+                {
+                    "name": "CII-Best-Practices",
+                    "score": 0,
+                    "reason": "no badge detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has an OpenSSF (formerly CII) Best Practices Badge.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#cii-best-practices"
+                    }
+                },
+                {
+                    "name": "Code-Review",
+                    "score": 10,
+                    "reason": "22 out of last 22 changesets reviewed before merge -- score normalized to 10",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project requires code review before pull requests (aka merge requests) are merged.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#code-review"
+                    }
+                },
+                {
+                    "name": "Contributors",
+                    "score": 10,
+                    "reason": "39 different organizations found -- score normalized to 10",
+                    "details": [
+                        "Info: contributors work for BreizhJUG,Dockins,FyneHeroes,WP-Team-Bach,allons-y,amontourdeprogrammer,anonaddy,atlassian,breizhcamp,chad metcalf,ci-reporter,cnabio,compose-spec,containerd,daytonaio,degreed,depcheck,distribution,docker,docker-archive,docker-captains,dockersamples,docsorg,focus-on-systems,full city tech co.,github-beta,go-docker,goreleaser,jnr,jruby,librenms,magefile,maintainers,moby,neard,opencontainers,portapps,thajeztah,tilt-dev"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project has a set of contributors from multiple organizations (e.g., companies).",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#contributors"
+                    }
+                },
+                {
+                    "name": "Dangerous-Workflow",
+                    "score": 10,
+                    "reason": "no dangerous workflow patterns detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project's GitHub Action workflows avoid dangerous patterns.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#dangerous-workflow"
+                    }
+                },
+                {
+                    "name": "Dependency-Update-Tool",
+                    "score": 10,
+                    "reason": "update tool detected",
+                    "details": [
+                        "Info: Dependabot detected: .github/dependabot.yml:1"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project uses a dependency update tool.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#dependency-update-tool"
+                    }
+                },
+                {
+                    "name": "Fuzzing",
+                    "score": -1,
+                    "reason": "internal error: internal error: Client.Search.Code: Search.Code: GET https://api.github.com/search/code?q=github.com+docker+compose+repo%3Agoogle%2Foss-fuzz+in%3Afile+filename%3Aproject.yaml: 403 You have exceeded a secondary rate limit. Please wait a few minutes before you try again. If you reach out to GitHub Support for help, please include the request ID 5858:8923:4BF59:90008:65F859D0. []",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project uses fuzzing.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#fuzzing"
+                    }
+                },
+                {
+                    "name": "License",
+                    "score": 10,
+                    "reason": "license file detected",
+                    "details": [
+                        "Info: : LICENSE:1"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project has defined a license.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#license"
+                    }
+                },
+                {
+                    "name": "Maintained",
+                    "score": 10,
+                    "reason": "30 commit(s) out of 30 and 1 issue activity out of 30 found in the last 90 days -- score normalized to 10",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project is \"actively maintained\".",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#maintained"
+                    }
+                },
+                {
+                    "name": "Packaging",
+                    "score": -1,
+                    "reason": "no published package detected",
+                    "details": [
+                        "Warn: no GitHub publishing workflow detected"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project is published as a package that others can easily download, install, easily update, and uninstall.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#packaging"
+                    }
+                },
+                {
+                    "name": "Pinned-Dependencies",
+                    "score": -1,
+                    "reason": "internal error: error parsing shell code: Dockerfile:1:1: unclosed here-document 'EOT'",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has declared and pinned the dependencies of its build process.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#pinned-dependencies"
+                    }
+                },
+                {
+                    "name": "SAST",
+                    "score": -1,
+                    "reason": "internal error: Client.Search.Code: Search.Code: GET https://api.github.com/search/code?q=github+codeql-action+analyze+repo%3Adocker%2Fcompose+path%3A%2F.github%2Fworkflows: 403 You have exceeded a secondary rate limit. Please wait a few minutes before you try again. If you reach out to GitHub Support for help, please include the request ID 5858:8923:4BF0C:8FF6D:65F859CF. []",
+                    "details": [
+                        "Warn: 0 commits out of 30 are checked with a SAST tool"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project uses static code analysis.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#sast"
+                    }
+                },
+                {
+                    "name": "Security-Policy",
+                    "score": 0,
+                    "reason": "security policy file not detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has published a security policy.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#security-policy"
+                    }
+                },
+                {
+                    "name": "Signed-Releases",
+                    "score": 0,
+                    "reason": "0 out of 5 artifacts are signed or have provenance",
+                    "details": [
+                        "Warn: release artifact v2.25.0 does not have provenance: https://api.github.com/repos/docker/compose/releases/146766600",
+                        "Warn: release artifact v2.25.0 not signed: https://api.github.com/repos/docker/compose/releases/146766600",
+                        "Warn: release artifact v2.24.7 does not have provenance: https://api.github.com/repos/docker/compose/releases/144954606",
+                        "Warn: release artifact v2.24.7 not signed: https://api.github.com/repos/docker/compose/releases/144954606",
+                        "Warn: release artifact v2.24.6 does not have provenance: https://api.github.com/repos/docker/compose/releases/142153265",
+                        "Warn: release artifact v2.24.6 not signed: https://api.github.com/repos/docker/compose/releases/142153265",
+                        "Warn: release artifact v2.24.5 does not have provenance: https://api.github.com/repos/docker/compose/releases/139179155",
+                        "Warn: release artifact v2.24.5 not signed: https://api.github.com/repos/docker/compose/releases/139179155",
+                        "Warn: release artifact v2.24.4 does not have provenance: https://api.github.com/repos/docker/compose/releases/139010398",
+                        "Warn: release artifact v2.24.4 not signed: https://api.github.com/repos/docker/compose/releases/139010398"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project cryptographically signs release artifacts.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#signed-releases"
+                    }
+                },
+                {
+                    "name": "Token-Permissions",
+                    "score": 0,
+                    "reason": "non read-only tokens detected in GitHub workflows",
+                    "details": [
+                        "Info: topLevel 'contents' permission set to 'read': .github/workflows/ci.yml:25: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/ci.yml/main?enable=permissions",
+                        "Warn: jobLevel 'contents' permission set to 'write': .github/workflows/ci.yml:256: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/ci.yml/main?enable=permissions",
+                        "Warn: no topLevel permission defined: .github/workflows/codeql.yml:1: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/codeql.yml/main?enable=permissions",
+                        "Info: jobLevel 'actions' permission set to 'read': .github/workflows/codeql.yml:26: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/codeql.yml/main?enable=permissions",
+                        "Info: jobLevel 'contents' permission set to 'read': .github/workflows/codeql.yml:27: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/codeql.yml/main?enable=permissions",
+                        "Warn: no topLevel permission defined: .github/workflows/docs-upstream.yml:1: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/docs-upstream.yml/main?enable=permissions",
+                        "Info: topLevel 'contents' permission set to 'read': .github/workflows/merge.yml:15: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/merge.yml/main?enable=permissions",
+                        "Info: topLevel permissions set to 'read-all': .github/workflows/scorecards.yml:11: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/scorecards.yml/main?enable=permissions"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project's workflows follow the principle of least privilege.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#token-permissions"
+                    }
+                },
+                {
+                    "name": "Vulnerabilities",
+                    "score": 10,
+                    "reason": "no vulnerabilities detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has open, known unfixed vulnerabilities.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#vulnerabilities"
+                    }
+                }
+            ]
+        },
+        "failure_reason":""
+    },
+    {
+        "name":"github.com/aymerick/raymond",
+        "version":"v2.0.3-0.20180322193309-b565731e1464",
+        "dependency_score":{
+            "date": "2024-03-18",
+            "score": 7.1,
+            "checks": [
+                {
+                    "name": "Binary-Artifacts",
+                    "score": 10,
+                    "reason": "no binaries found in the repo",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has generated executable (binary) artifacts in the source repository.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#binary-artifacts"
+                    }
+                },
+                {
+                    "name": "Branch-Protection",
+                    "score": -1,
+                    "reason": "internal error: error during branchesHandler.setup: internal error: githubv4.Query: Resource not accessible by integration",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the default and release branches are protected with GitHub's branch protection settings.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#branch-protection"
+                    }
+                },
+                {
+                    "name": "CI-Tests",
+                    "score": 10,
+                    "reason": "22 out of 22 merged PRs checked by a CI test -- score normalized to 10",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project runs tests before pull requests are merged.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#ci-tests"
+                    }
+                },
+                {
+                    "name": "CII-Best-Practices",
+                    "score": 0,
+                    "reason": "no badge detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has an OpenSSF (formerly CII) Best Practices Badge.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#cii-best-practices"
+                    }
+                },
+                {
+                    "name": "Code-Review",
+                    "score": 10,
+                    "reason": "22 out of last 22 changesets reviewed before merge -- score normalized to 10",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project requires code review before pull requests (aka merge requests) are merged.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#code-review"
+                    }
+                },
+                {
+                    "name": "Contributors",
+                    "score": 10,
+                    "reason": "39 different organizations found -- score normalized to 10",
+                    "details": [
+                        "Info: contributors work for BreizhJUG,Dockins,FyneHeroes,WP-Team-Bach,allons-y,amontourdeprogrammer,anonaddy,atlassian,breizhcamp,chad metcalf,ci-reporter,cnabio,compose-spec,containerd,daytonaio,degreed,depcheck,distribution,docker,docker-archive,docker-captains,dockersamples,docsorg,focus-on-systems,full city tech co.,github-beta,go-docker,goreleaser,jnr,jruby,librenms,magefile,maintainers,moby,neard,opencontainers,portapps,thajeztah,tilt-dev"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project has a set of contributors from multiple organizations (e.g., companies).",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#contributors"
+                    }
+                },
+                {
+                    "name": "Dangerous-Workflow",
+                    "score": 10,
+                    "reason": "no dangerous workflow patterns detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project's GitHub Action workflows avoid dangerous patterns.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#dangerous-workflow"
+                    }
+                },
+                {
+                    "name": "Dependency-Update-Tool",
+                    "score": 10,
+                    "reason": "update tool detected",
+                    "details": [
+                        "Info: Dependabot detected: .github/dependabot.yml:1"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project uses a dependency update tool.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#dependency-update-tool"
+                    }
+                },
+                {
+                    "name": "Fuzzing",
+                    "score": -1,
+                    "reason": "internal error: internal error: Client.Search.Code: Search.Code: GET https://api.github.com/search/code?q=github.com+docker+compose+repo%3Agoogle%2Foss-fuzz+in%3Afile+filename%3Aproject.yaml: 403 You have exceeded a secondary rate limit. Please wait a few minutes before you try again. If you reach out to GitHub Support for help, please include the request ID 5858:8923:4BF59:90008:65F859D0. []",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project uses fuzzing.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#fuzzing"
+                    }
+                },
+                {
+                    "name": "License",
+                    "score": 10,
+                    "reason": "license file detected",
+                    "details": [
+                        "Info: : LICENSE:1"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project has defined a license.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#license"
+                    }
+                },
+                {
+                    "name": "Maintained",
+                    "score": 10,
+                    "reason": "30 commit(s) out of 30 and 1 issue activity out of 30 found in the last 90 days -- score normalized to 10",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project is \"actively maintained\".",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#maintained"
+                    }
+                },
+                {
+                    "name": "Packaging",
+                    "score": -1,
+                    "reason": "no published package detected",
+                    "details": [
+                        "Warn: no GitHub publishing workflow detected"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project is published as a package that others can easily download, install, easily update, and uninstall.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#packaging"
+                    }
+                },
+                {
+                    "name": "Pinned-Dependencies",
+                    "score": -1,
+                    "reason": "internal error: error parsing shell code: Dockerfile:1:1: unclosed here-document 'EOT'",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has declared and pinned the dependencies of its build process.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#pinned-dependencies"
+                    }
+                },
+                {
+                    "name": "SAST",
+                    "score": -1,
+                    "reason": "internal error: Client.Search.Code: Search.Code: GET https://api.github.com/search/code?q=github+codeql-action+analyze+repo%3Adocker%2Fcompose+path%3A%2F.github%2Fworkflows: 403 You have exceeded a secondary rate limit. Please wait a few minutes before you try again. If you reach out to GitHub Support for help, please include the request ID 5858:8923:4BF0C:8FF6D:65F859CF. []",
+                    "details": [
+                        "Warn: 0 commits out of 30 are checked with a SAST tool"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project uses static code analysis.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#sast"
+                    }
+                },
+                {
+                    "name": "Security-Policy",
+                    "score": 0,
+                    "reason": "security policy file not detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has published a security policy.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#security-policy"
+                    }
+                },
+                {
+                    "name": "Signed-Releases",
+                    "score": 0,
+                    "reason": "0 out of 5 artifacts are signed or have provenance",
+                    "details": [
+                        "Warn: release artifact v2.25.0 does not have provenance: https://api.github.com/repos/docker/compose/releases/146766600",
+                        "Warn: release artifact v2.25.0 not signed: https://api.github.com/repos/docker/compose/releases/146766600",
+                        "Warn: release artifact v2.24.7 does not have provenance: https://api.github.com/repos/docker/compose/releases/144954606",
+                        "Warn: release artifact v2.24.7 not signed: https://api.github.com/repos/docker/compose/releases/144954606",
+                        "Warn: release artifact v2.24.6 does not have provenance: https://api.github.com/repos/docker/compose/releases/142153265",
+                        "Warn: release artifact v2.24.6 not signed: https://api.github.com/repos/docker/compose/releases/142153265",
+                        "Warn: release artifact v2.24.5 does not have provenance: https://api.github.com/repos/docker/compose/releases/139179155",
+                        "Warn: release artifact v2.24.5 not signed: https://api.github.com/repos/docker/compose/releases/139179155",
+                        "Warn: release artifact v2.24.4 does not have provenance: https://api.github.com/repos/docker/compose/releases/139010398",
+                        "Warn: release artifact v2.24.4 not signed: https://api.github.com/repos/docker/compose/releases/139010398"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project cryptographically signs release artifacts.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#signed-releases"
+                    }
+                },
+                {
+                    "name": "Token-Permissions",
+                    "score": 0,
+                    "reason": "non read-only tokens detected in GitHub workflows",
+                    "details": [
+                        "Info: topLevel 'contents' permission set to 'read': .github/workflows/ci.yml:25: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/ci.yml/main?enable=permissions",
+                        "Warn: jobLevel 'contents' permission set to 'write': .github/workflows/ci.yml:256: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/ci.yml/main?enable=permissions",
+                        "Warn: no topLevel permission defined: .github/workflows/codeql.yml:1: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/codeql.yml/main?enable=permissions",
+                        "Info: jobLevel 'actions' permission set to 'read': .github/workflows/codeql.yml:26: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/codeql.yml/main?enable=permissions",
+                        "Info: jobLevel 'contents' permission set to 'read': .github/workflows/codeql.yml:27: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/codeql.yml/main?enable=permissions",
+                        "Warn: no topLevel permission defined: .github/workflows/docs-upstream.yml:1: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/docs-upstream.yml/main?enable=permissions",
+                        "Info: topLevel 'contents' permission set to 'read': .github/workflows/merge.yml:15: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/merge.yml/main?enable=permissions",
+                        "Info: topLevel permissions set to 'read-all': .github/workflows/scorecards.yml:11: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/scorecards.yml/main?enable=permissions"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project's workflows follow the principle of least privilege.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#token-permissions"
+                    }
+                },
+                {
+                    "name": "Vulnerabilities",
+                    "score": 10,
+                    "reason": "no vulnerabilities detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has open, known unfixed vulnerabilities.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#vulnerabilities"
+                    }
+                }
+            ]
+        },
+        "failure_reason":""
+    },
+    {
+        "name":"github.com/chzyer/logex",
+        "version":"v1.1.10",
+        "dependency_score":{
+            "date": "2024-03-18",
+            "score": 7.1,
+            "checks": [
+                {
+                    "name": "Binary-Artifacts",
+                    "score": 10,
+                    "reason": "no binaries found in the repo",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has generated executable (binary) artifacts in the source repository.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#binary-artifacts"
+                    }
+                },
+                {
+                    "name": "Branch-Protection",
+                    "score": -1,
+                    "reason": "internal error: error during branchesHandler.setup: internal error: githubv4.Query: Resource not accessible by integration",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the default and release branches are protected with GitHub's branch protection settings.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#branch-protection"
+                    }
+                },
+                {
+                    "name": "CI-Tests",
+                    "score": 10,
+                    "reason": "22 out of 22 merged PRs checked by a CI test -- score normalized to 10",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project runs tests before pull requests are merged.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#ci-tests"
+                    }
+                },
+                {
+                    "name": "CII-Best-Practices",
+                    "score": 0,
+                    "reason": "no badge detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has an OpenSSF (formerly CII) Best Practices Badge.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#cii-best-practices"
+                    }
+                },
+                {
+                    "name": "Code-Review",
+                    "score": 10,
+                    "reason": "22 out of last 22 changesets reviewed before merge -- score normalized to 10",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project requires code review before pull requests (aka merge requests) are merged.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#code-review"
+                    }
+                },
+                {
+                    "name": "Contributors",
+                    "score": 10,
+                    "reason": "39 different organizations found -- score normalized to 10",
+                    "details": [
+                        "Info: contributors work for BreizhJUG,Dockins,FyneHeroes,WP-Team-Bach,allons-y,amontourdeprogrammer,anonaddy,atlassian,breizhcamp,chad metcalf,ci-reporter,cnabio,compose-spec,containerd,daytonaio,degreed,depcheck,distribution,docker,docker-archive,docker-captains,dockersamples,docsorg,focus-on-systems,full city tech co.,github-beta,go-docker,goreleaser,jnr,jruby,librenms,magefile,maintainers,moby,neard,opencontainers,portapps,thajeztah,tilt-dev"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project has a set of contributors from multiple organizations (e.g., companies).",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#contributors"
+                    }
+                },
+                {
+                    "name": "Dangerous-Workflow",
+                    "score": 10,
+                    "reason": "no dangerous workflow patterns detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project's GitHub Action workflows avoid dangerous patterns.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#dangerous-workflow"
+                    }
+                },
+                {
+                    "name": "Dependency-Update-Tool",
+                    "score": 10,
+                    "reason": "update tool detected",
+                    "details": [
+                        "Info: Dependabot detected: .github/dependabot.yml:1"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project uses a dependency update tool.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#dependency-update-tool"
+                    }
+                },
+                {
+                    "name": "Fuzzing",
+                    "score": -1,
+                    "reason": "internal error: internal error: Client.Search.Code: Search.Code: GET https://api.github.com/search/code?q=github.com+docker+compose+repo%3Agoogle%2Foss-fuzz+in%3Afile+filename%3Aproject.yaml: 403 You have exceeded a secondary rate limit. Please wait a few minutes before you try again. If you reach out to GitHub Support for help, please include the request ID 5858:8923:4BF59:90008:65F859D0. []",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project uses fuzzing.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#fuzzing"
+                    }
+                },
+                {
+                    "name": "License",
+                    "score": 10,
+                    "reason": "license file detected",
+                    "details": [
+                        "Info: : LICENSE:1"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project has defined a license.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#license"
+                    }
+                },
+                {
+                    "name": "Maintained",
+                    "score": 10,
+                    "reason": "30 commit(s) out of 30 and 1 issue activity out of 30 found in the last 90 days -- score normalized to 10",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project is \"actively maintained\".",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#maintained"
+                    }
+                },
+                {
+                    "name": "Packaging",
+                    "score": -1,
+                    "reason": "no published package detected",
+                    "details": [
+                        "Warn: no GitHub publishing workflow detected"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project is published as a package that others can easily download, install, easily update, and uninstall.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#packaging"
+                    }
+                },
+                {
+                    "name": "Pinned-Dependencies",
+                    "score": -1,
+                    "reason": "internal error: error parsing shell code: Dockerfile:1:1: unclosed here-document 'EOT'",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has declared and pinned the dependencies of its build process.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#pinned-dependencies"
+                    }
+                },
+                {
+                    "name": "SAST",
+                    "score": -1,
+                    "reason": "internal error: Client.Search.Code: Search.Code: GET https://api.github.com/search/code?q=github+codeql-action+analyze+repo%3Adocker%2Fcompose+path%3A%2F.github%2Fworkflows: 403 You have exceeded a secondary rate limit. Please wait a few minutes before you try again. If you reach out to GitHub Support for help, please include the request ID 5858:8923:4BF0C:8FF6D:65F859CF. []",
+                    "details": [
+                        "Warn: 0 commits out of 30 are checked with a SAST tool"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project uses static code analysis.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#sast"
+                    }
+                },
+                {
+                    "name": "Security-Policy",
+                    "score": 0,
+                    "reason": "security policy file not detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has published a security policy.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#security-policy"
+                    }
+                },
+                {
+                    "name": "Signed-Releases",
+                    "score": 0,
+                    "reason": "0 out of 5 artifacts are signed or have provenance",
+                    "details": [
+                        "Warn: release artifact v2.25.0 does not have provenance: https://api.github.com/repos/docker/compose/releases/146766600",
+                        "Warn: release artifact v2.25.0 not signed: https://api.github.com/repos/docker/compose/releases/146766600",
+                        "Warn: release artifact v2.24.7 does not have provenance: https://api.github.com/repos/docker/compose/releases/144954606",
+                        "Warn: release artifact v2.24.7 not signed: https://api.github.com/repos/docker/compose/releases/144954606",
+                        "Warn: release artifact v2.24.6 does not have provenance: https://api.github.com/repos/docker/compose/releases/142153265",
+                        "Warn: release artifact v2.24.6 not signed: https://api.github.com/repos/docker/compose/releases/142153265",
+                        "Warn: release artifact v2.24.5 does not have provenance: https://api.github.com/repos/docker/compose/releases/139179155",
+                        "Warn: release artifact v2.24.5 not signed: https://api.github.com/repos/docker/compose/releases/139179155",
+                        "Warn: release artifact v2.24.4 does not have provenance: https://api.github.com/repos/docker/compose/releases/139010398",
+                        "Warn: release artifact v2.24.4 not signed: https://api.github.com/repos/docker/compose/releases/139010398"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project cryptographically signs release artifacts.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#signed-releases"
+                    }
+                },
+                {
+                    "name": "Token-Permissions",
+                    "score": 0,
+                    "reason": "non read-only tokens detected in GitHub workflows",
+                    "details": [
+                        "Info: topLevel 'contents' permission set to 'read': .github/workflows/ci.yml:25: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/ci.yml/main?enable=permissions",
+                        "Warn: jobLevel 'contents' permission set to 'write': .github/workflows/ci.yml:256: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/ci.yml/main?enable=permissions",
+                        "Warn: no topLevel permission defined: .github/workflows/codeql.yml:1: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/codeql.yml/main?enable=permissions",
+                        "Info: jobLevel 'actions' permission set to 'read': .github/workflows/codeql.yml:26: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/codeql.yml/main?enable=permissions",
+                        "Info: jobLevel 'contents' permission set to 'read': .github/workflows/codeql.yml:27: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/codeql.yml/main?enable=permissions",
+                        "Warn: no topLevel permission defined: .github/workflows/docs-upstream.yml:1: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/docs-upstream.yml/main?enable=permissions",
+                        "Info: topLevel 'contents' permission set to 'read': .github/workflows/merge.yml:15: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/merge.yml/main?enable=permissions",
+                        "Info: topLevel permissions set to 'read-all': .github/workflows/scorecards.yml:11: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/scorecards.yml/main?enable=permissions"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project's workflows follow the principle of least privilege.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#token-permissions"
+                    }
+                },
+                {
+                    "name": "Vulnerabilities",
+                    "score": 10,
+                    "reason": "no vulnerabilities detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has open, known unfixed vulnerabilities.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#vulnerabilities"
+                    }
+                }
+            ]
+        },
+        "failure_reason":""
+    },
+    {
+        "name":"github.com/chzyer/test",
+        "version":"v0.0.0-20180213035817-a1ea475d72b1",
+        "dependency_score":{
+            "date": "2024-03-18",
+            "score": 7.1,
+            "checks": [
+                {
+                    "name": "Binary-Artifacts",
+                    "score": 10,
+                    "reason": "no binaries found in the repo",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has generated executable (binary) artifacts in the source repository.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#binary-artifacts"
+                    }
+                },
+                {
+                    "name": "Branch-Protection",
+                    "score": -1,
+                    "reason": "internal error: error during branchesHandler.setup: internal error: githubv4.Query: Resource not accessible by integration",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the default and release branches are protected with GitHub's branch protection settings.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#branch-protection"
+                    }
+                },
+                {
+                    "name": "CI-Tests",
+                    "score": 10,
+                    "reason": "22 out of 22 merged PRs checked by a CI test -- score normalized to 10",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project runs tests before pull requests are merged.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#ci-tests"
+                    }
+                },
+                {
+                    "name": "CII-Best-Practices",
+                    "score": 0,
+                    "reason": "no badge detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has an OpenSSF (formerly CII) Best Practices Badge.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#cii-best-practices"
+                    }
+                },
+                {
+                    "name": "Code-Review",
+                    "score": 10,
+                    "reason": "22 out of last 22 changesets reviewed before merge -- score normalized to 10",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project requires code review before pull requests (aka merge requests) are merged.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#code-review"
+                    }
+                },
+                {
+                    "name": "Contributors",
+                    "score": 10,
+                    "reason": "39 different organizations found -- score normalized to 10",
+                    "details": [
+                        "Info: contributors work for BreizhJUG,Dockins,FyneHeroes,WP-Team-Bach,allons-y,amontourdeprogrammer,anonaddy,atlassian,breizhcamp,chad metcalf,ci-reporter,cnabio,compose-spec,containerd,daytonaio,degreed,depcheck,distribution,docker,docker-archive,docker-captains,dockersamples,docsorg,focus-on-systems,full city tech co.,github-beta,go-docker,goreleaser,jnr,jruby,librenms,magefile,maintainers,moby,neard,opencontainers,portapps,thajeztah,tilt-dev"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project has a set of contributors from multiple organizations (e.g., companies).",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#contributors"
+                    }
+                },
+                {
+                    "name": "Dangerous-Workflow",
+                    "score": 10,
+                    "reason": "no dangerous workflow patterns detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project's GitHub Action workflows avoid dangerous patterns.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#dangerous-workflow"
+                    }
+                },
+                {
+                    "name": "Dependency-Update-Tool",
+                    "score": 10,
+                    "reason": "update tool detected",
+                    "details": [
+                        "Info: Dependabot detected: .github/dependabot.yml:1"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project uses a dependency update tool.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#dependency-update-tool"
+                    }
+                },
+                {
+                    "name": "Fuzzing",
+                    "score": -1,
+                    "reason": "internal error: internal error: Client.Search.Code: Search.Code: GET https://api.github.com/search/code?q=github.com+docker+compose+repo%3Agoogle%2Foss-fuzz+in%3Afile+filename%3Aproject.yaml: 403 You have exceeded a secondary rate limit. Please wait a few minutes before you try again. If you reach out to GitHub Support for help, please include the request ID 5858:8923:4BF59:90008:65F859D0. []",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project uses fuzzing.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#fuzzing"
+                    }
+                },
+                {
+                    "name": "License",
+                    "score": 10,
+                    "reason": "license file detected",
+                    "details": [
+                        "Info: : LICENSE:1"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project has defined a license.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#license"
+                    }
+                },
+                {
+                    "name": "Maintained",
+                    "score": 10,
+                    "reason": "30 commit(s) out of 30 and 1 issue activity out of 30 found in the last 90 days -- score normalized to 10",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project is \"actively maintained\".",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#maintained"
+                    }
+                },
+                {
+                    "name": "Packaging",
+                    "score": -1,
+                    "reason": "no published package detected",
+                    "details": [
+                        "Warn: no GitHub publishing workflow detected"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project is published as a package that others can easily download, install, easily update, and uninstall.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#packaging"
+                    }
+                },
+                {
+                    "name": "Pinned-Dependencies",
+                    "score": -1,
+                    "reason": "internal error: error parsing shell code: Dockerfile:1:1: unclosed here-document 'EOT'",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has declared and pinned the dependencies of its build process.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#pinned-dependencies"
+                    }
+                },
+                {
+                    "name": "SAST",
+                    "score": -1,
+                    "reason": "internal error: Client.Search.Code: Search.Code: GET https://api.github.com/search/code?q=github+codeql-action+analyze+repo%3Adocker%2Fcompose+path%3A%2F.github%2Fworkflows: 403 You have exceeded a secondary rate limit. Please wait a few minutes before you try again. If you reach out to GitHub Support for help, please include the request ID 5858:8923:4BF0C:8FF6D:65F859CF. []",
+                    "details": [
+                        "Warn: 0 commits out of 30 are checked with a SAST tool"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project uses static code analysis.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#sast"
+                    }
+                },
+                {
+                    "name": "Security-Policy",
+                    "score": 0,
+                    "reason": "security policy file not detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has published a security policy.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#security-policy"
+                    }
+                },
+                {
+                    "name": "Signed-Releases",
+                    "score": 0,
+                    "reason": "0 out of 5 artifacts are signed or have provenance",
+                    "details": [
+                        "Warn: release artifact v2.25.0 does not have provenance: https://api.github.com/repos/docker/compose/releases/146766600",
+                        "Warn: release artifact v2.25.0 not signed: https://api.github.com/repos/docker/compose/releases/146766600",
+                        "Warn: release artifact v2.24.7 does not have provenance: https://api.github.com/repos/docker/compose/releases/144954606",
+                        "Warn: release artifact v2.24.7 not signed: https://api.github.com/repos/docker/compose/releases/144954606",
+                        "Warn: release artifact v2.24.6 does not have provenance: https://api.github.com/repos/docker/compose/releases/142153265",
+                        "Warn: release artifact v2.24.6 not signed: https://api.github.com/repos/docker/compose/releases/142153265",
+                        "Warn: release artifact v2.24.5 does not have provenance: https://api.github.com/repos/docker/compose/releases/139179155",
+                        "Warn: release artifact v2.24.5 not signed: https://api.github.com/repos/docker/compose/releases/139179155",
+                        "Warn: release artifact v2.24.4 does not have provenance: https://api.github.com/repos/docker/compose/releases/139010398",
+                        "Warn: release artifact v2.24.4 not signed: https://api.github.com/repos/docker/compose/releases/139010398"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project cryptographically signs release artifacts.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#signed-releases"
+                    }
+                },
+                {
+                    "name": "Token-Permissions",
+                    "score": 0,
+                    "reason": "non read-only tokens detected in GitHub workflows",
+                    "details": [
+                        "Info: topLevel 'contents' permission set to 'read': .github/workflows/ci.yml:25: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/ci.yml/main?enable=permissions",
+                        "Warn: jobLevel 'contents' permission set to 'write': .github/workflows/ci.yml:256: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/ci.yml/main?enable=permissions",
+                        "Warn: no topLevel permission defined: .github/workflows/codeql.yml:1: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/codeql.yml/main?enable=permissions",
+                        "Info: jobLevel 'actions' permission set to 'read': .github/workflows/codeql.yml:26: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/codeql.yml/main?enable=permissions",
+                        "Info: jobLevel 'contents' permission set to 'read': .github/workflows/codeql.yml:27: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/codeql.yml/main?enable=permissions",
+                        "Warn: no topLevel permission defined: .github/workflows/docs-upstream.yml:1: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/docs-upstream.yml/main?enable=permissions",
+                        "Info: topLevel 'contents' permission set to 'read': .github/workflows/merge.yml:15: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/merge.yml/main?enable=permissions",
+                        "Info: topLevel permissions set to 'read-all': .github/workflows/scorecards.yml:11: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/scorecards.yml/main?enable=permissions"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project's workflows follow the principle of least privilege.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#token-permissions"
+                    }
+                },
+                {
+                    "name": "Vulnerabilities",
+                    "score": 10,
+                    "reason": "no vulnerabilities detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has open, known unfixed vulnerabilities.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#vulnerabilities"
+                    }
+                }
+            ]
+        },
+        "failure_reason":""
+    },
+    {
+        "name":"github.com/codegangsta/inject",
+        "version":"v0.0.0-20150114235600-33e0aa1cb7c0",
+        "dependency_score":{
+            "date": "2024-03-18",
+            "score": 7.1,
+            "checks": [
+                {
+                    "name": "Binary-Artifacts",
+                    "score": 10,
+                    "reason": "no binaries found in the repo",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has generated executable (binary) artifacts in the source repository.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#binary-artifacts"
+                    }
+                },
+                {
+                    "name": "Branch-Protection",
+                    "score": -1,
+                    "reason": "internal error: error during branchesHandler.setup: internal error: githubv4.Query: Resource not accessible by integration",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the default and release branches are protected with GitHub's branch protection settings.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#branch-protection"
+                    }
+                },
+                {
+                    "name": "CI-Tests",
+                    "score": 10,
+                    "reason": "22 out of 22 merged PRs checked by a CI test -- score normalized to 10",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project runs tests before pull requests are merged.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#ci-tests"
+                    }
+                },
+                {
+                    "name": "CII-Best-Practices",
+                    "score": 0,
+                    "reason": "no badge detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has an OpenSSF (formerly CII) Best Practices Badge.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#cii-best-practices"
+                    }
+                },
+                {
+                    "name": "Code-Review",
+                    "score": 10,
+                    "reason": "22 out of last 22 changesets reviewed before merge -- score normalized to 10",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project requires code review before pull requests (aka merge requests) are merged.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#code-review"
+                    }
+                },
+                {
+                    "name": "Contributors",
+                    "score": 10,
+                    "reason": "39 different organizations found -- score normalized to 10",
+                    "details": [
+                        "Info: contributors work for BreizhJUG,Dockins,FyneHeroes,WP-Team-Bach,allons-y,amontourdeprogrammer,anonaddy,atlassian,breizhcamp,chad metcalf,ci-reporter,cnabio,compose-spec,containerd,daytonaio,degreed,depcheck,distribution,docker,docker-archive,docker-captains,dockersamples,docsorg,focus-on-systems,full city tech co.,github-beta,go-docker,goreleaser,jnr,jruby,librenms,magefile,maintainers,moby,neard,opencontainers,portapps,thajeztah,tilt-dev"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project has a set of contributors from multiple organizations (e.g., companies).",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#contributors"
+                    }
+                },
+                {
+                    "name": "Dangerous-Workflow",
+                    "score": 10,
+                    "reason": "no dangerous workflow patterns detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project's GitHub Action workflows avoid dangerous patterns.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#dangerous-workflow"
+                    }
+                },
+                {
+                    "name": "Dependency-Update-Tool",
+                    "score": 10,
+                    "reason": "update tool detected",
+                    "details": [
+                        "Info: Dependabot detected: .github/dependabot.yml:1"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project uses a dependency update tool.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#dependency-update-tool"
+                    }
+                },
+                {
+                    "name": "Fuzzing",
+                    "score": -1,
+                    "reason": "internal error: internal error: Client.Search.Code: Search.Code: GET https://api.github.com/search/code?q=github.com+docker+compose+repo%3Agoogle%2Foss-fuzz+in%3Afile+filename%3Aproject.yaml: 403 You have exceeded a secondary rate limit. Please wait a few minutes before you try again. If you reach out to GitHub Support for help, please include the request ID 5858:8923:4BF59:90008:65F859D0. []",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project uses fuzzing.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#fuzzing"
+                    }
+                },
+                {
+                    "name": "License",
+                    "score": 10,
+                    "reason": "license file detected",
+                    "details": [
+                        "Info: : LICENSE:1"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project has defined a license.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#license"
+                    }
+                },
+                {
+                    "name": "Maintained",
+                    "score": 10,
+                    "reason": "30 commit(s) out of 30 and 1 issue activity out of 30 found in the last 90 days -- score normalized to 10",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project is \"actively maintained\".",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#maintained"
+                    }
+                },
+                {
+                    "name": "Packaging",
+                    "score": -1,
+                    "reason": "no published package detected",
+                    "details": [
+                        "Warn: no GitHub publishing workflow detected"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project is published as a package that others can easily download, install, easily update, and uninstall.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#packaging"
+                    }
+                },
+                {
+                    "name": "Pinned-Dependencies",
+                    "score": -1,
+                    "reason": "internal error: error parsing shell code: Dockerfile:1:1: unclosed here-document 'EOT'",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has declared and pinned the dependencies of its build process.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#pinned-dependencies"
+                    }
+                },
+                {
+                    "name": "SAST",
+                    "score": -1,
+                    "reason": "internal error: Client.Search.Code: Search.Code: GET https://api.github.com/search/code?q=github+codeql-action+analyze+repo%3Adocker%2Fcompose+path%3A%2F.github%2Fworkflows: 403 You have exceeded a secondary rate limit. Please wait a few minutes before you try again. If you reach out to GitHub Support for help, please include the request ID 5858:8923:4BF0C:8FF6D:65F859CF. []",
+                    "details": [
+                        "Warn: 0 commits out of 30 are checked with a SAST tool"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project uses static code analysis.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#sast"
+                    }
+                },
+                {
+                    "name": "Security-Policy",
+                    "score": 0,
+                    "reason": "security policy file not detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has published a security policy.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#security-policy"
+                    }
+                },
+                {
+                    "name": "Signed-Releases",
+                    "score": 0,
+                    "reason": "0 out of 5 artifacts are signed or have provenance",
+                    "details": [
+                        "Warn: release artifact v2.25.0 does not have provenance: https://api.github.com/repos/docker/compose/releases/146766600",
+                        "Warn: release artifact v2.25.0 not signed: https://api.github.com/repos/docker/compose/releases/146766600",
+                        "Warn: release artifact v2.24.7 does not have provenance: https://api.github.com/repos/docker/compose/releases/144954606",
+                        "Warn: release artifact v2.24.7 not signed: https://api.github.com/repos/docker/compose/releases/144954606",
+                        "Warn: release artifact v2.24.6 does not have provenance: https://api.github.com/repos/docker/compose/releases/142153265",
+                        "Warn: release artifact v2.24.6 not signed: https://api.github.com/repos/docker/compose/releases/142153265",
+                        "Warn: release artifact v2.24.5 does not have provenance: https://api.github.com/repos/docker/compose/releases/139179155",
+                        "Warn: release artifact v2.24.5 not signed: https://api.github.com/repos/docker/compose/releases/139179155",
+                        "Warn: release artifact v2.24.4 does not have provenance: https://api.github.com/repos/docker/compose/releases/139010398",
+                        "Warn: release artifact v2.24.4 not signed: https://api.github.com/repos/docker/compose/releases/139010398"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project cryptographically signs release artifacts.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#signed-releases"
+                    }
+                },
+                {
+                    "name": "Token-Permissions",
+                    "score": 0,
+                    "reason": "non read-only tokens detected in GitHub workflows",
+                    "details": [
+                        "Info: topLevel 'contents' permission set to 'read': .github/workflows/ci.yml:25: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/ci.yml/main?enable=permissions",
+                        "Warn: jobLevel 'contents' permission set to 'write': .github/workflows/ci.yml:256: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/ci.yml/main?enable=permissions",
+                        "Warn: no topLevel permission defined: .github/workflows/codeql.yml:1: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/codeql.yml/main?enable=permissions",
+                        "Info: jobLevel 'actions' permission set to 'read': .github/workflows/codeql.yml:26: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/codeql.yml/main?enable=permissions",
+                        "Info: jobLevel 'contents' permission set to 'read': .github/workflows/codeql.yml:27: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/codeql.yml/main?enable=permissions",
+                        "Warn: no topLevel permission defined: .github/workflows/docs-upstream.yml:1: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/docs-upstream.yml/main?enable=permissions",
+                        "Info: topLevel 'contents' permission set to 'read': .github/workflows/merge.yml:15: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/merge.yml/main?enable=permissions",
+                        "Info: topLevel permissions set to 'read-all': .github/workflows/scorecards.yml:11: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/scorecards.yml/main?enable=permissions"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project's workflows follow the principle of least privilege.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#token-permissions"
+                    }
+                },
+                {
+                    "name": "Vulnerabilities",
+                    "score": 10,
+                    "reason": "no vulnerabilities detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has open, known unfixed vulnerabilities.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#vulnerabilities"
+                    }
+                }
+            ]
+        },
+        "failure_reason":""
+    },
+    {
+        "name":"github.com/etcd-io/etcd",
+        "version":"v3.3.10",
+        "dependency_score":{
+            "date": "2024-03-18",
+            "score": 7.1,
+            "checks": [
+                {
+                    "name": "Binary-Artifacts",
+                    "score": 10,
+                    "reason": "no binaries found in the repo",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has generated executable (binary) artifacts in the source repository.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#binary-artifacts"
+                    }
+                },
+                {
+                    "name": "Branch-Protection",
+                    "score": -1,
+                    "reason": "internal error: error during branchesHandler.setup: internal error: githubv4.Query: Resource not accessible by integration",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the default and release branches are protected with GitHub's branch protection settings.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#branch-protection"
+                    }
+                },
+                {
+                    "name": "CI-Tests",
+                    "score": 10,
+                    "reason": "22 out of 22 merged PRs checked by a CI test -- score normalized to 10",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project runs tests before pull requests are merged.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#ci-tests"
+                    }
+                },
+                {
+                    "name": "CII-Best-Practices",
+                    "score": 0,
+                    "reason": "no badge detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has an OpenSSF (formerly CII) Best Practices Badge.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#cii-best-practices"
+                    }
+                },
+                {
+                    "name": "Code-Review",
+                    "score": 10,
+                    "reason": "22 out of last 22 changesets reviewed before merge -- score normalized to 10",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project requires code review before pull requests (aka merge requests) are merged.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#code-review"
+                    }
+                },
+                {
+                    "name": "Contributors",
+                    "score": 10,
+                    "reason": "39 different organizations found -- score normalized to 10",
+                    "details": [
+                        "Info: contributors work for BreizhJUG,Dockins,FyneHeroes,WP-Team-Bach,allons-y,amontourdeprogrammer,anonaddy,atlassian,breizhcamp,chad metcalf,ci-reporter,cnabio,compose-spec,containerd,daytonaio,degreed,depcheck,distribution,docker,docker-archive,docker-captains,dockersamples,docsorg,focus-on-systems,full city tech co.,github-beta,go-docker,goreleaser,jnr,jruby,librenms,magefile,maintainers,moby,neard,opencontainers,portapps,thajeztah,tilt-dev"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project has a set of contributors from multiple organizations (e.g., companies).",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#contributors"
+                    }
+                },
+                {
+                    "name": "Dangerous-Workflow",
+                    "score": 10,
+                    "reason": "no dangerous workflow patterns detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project's GitHub Action workflows avoid dangerous patterns.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#dangerous-workflow"
+                    }
+                },
+                {
+                    "name": "Dependency-Update-Tool",
+                    "score": 10,
+                    "reason": "update tool detected",
+                    "details": [
+                        "Info: Dependabot detected: .github/dependabot.yml:1"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project uses a dependency update tool.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#dependency-update-tool"
+                    }
+                },
+                {
+                    "name": "Fuzzing",
+                    "score": -1,
+                    "reason": "internal error: internal error: Client.Search.Code: Search.Code: GET https://api.github.com/search/code?q=github.com+docker+compose+repo%3Agoogle%2Foss-fuzz+in%3Afile+filename%3Aproject.yaml: 403 You have exceeded a secondary rate limit. Please wait a few minutes before you try again. If you reach out to GitHub Support for help, please include the request ID 5858:8923:4BF59:90008:65F859D0. []",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project uses fuzzing.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#fuzzing"
+                    }
+                },
+                {
+                    "name": "License",
+                    "score": 10,
+                    "reason": "license file detected",
+                    "details": [
+                        "Info: : LICENSE:1"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project has defined a license.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#license"
+                    }
+                },
+                {
+                    "name": "Maintained",
+                    "score": 10,
+                    "reason": "30 commit(s) out of 30 and 1 issue activity out of 30 found in the last 90 days -- score normalized to 10",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project is \"actively maintained\".",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#maintained"
+                    }
+                },
+                {
+                    "name": "Packaging",
+                    "score": -1,
+                    "reason": "no published package detected",
+                    "details": [
+                        "Warn: no GitHub publishing workflow detected"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project is published as a package that others can easily download, install, easily update, and uninstall.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#packaging"
+                    }
+                },
+                {
+                    "name": "Pinned-Dependencies",
+                    "score": -1,
+                    "reason": "internal error: error parsing shell code: Dockerfile:1:1: unclosed here-document 'EOT'",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has declared and pinned the dependencies of its build process.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#pinned-dependencies"
+                    }
+                },
+                {
+                    "name": "SAST",
+                    "score": -1,
+                    "reason": "internal error: Client.Search.Code: Search.Code: GET https://api.github.com/search/code?q=github+codeql-action+analyze+repo%3Adocker%2Fcompose+path%3A%2F.github%2Fworkflows: 403 You have exceeded a secondary rate limit. Please wait a few minutes before you try again. If you reach out to GitHub Support for help, please include the request ID 5858:8923:4BF0C:8FF6D:65F859CF. []",
+                    "details": [
+                        "Warn: 0 commits out of 30 are checked with a SAST tool"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project uses static code analysis.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#sast"
+                    }
+                },
+                {
+                    "name": "Security-Policy",
+                    "score": 0,
+                    "reason": "security policy file not detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has published a security policy.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#security-policy"
+                    }
+                },
+                {
+                    "name": "Signed-Releases",
+                    "score": 0,
+                    "reason": "0 out of 5 artifacts are signed or have provenance",
+                    "details": [
+                        "Warn: release artifact v2.25.0 does not have provenance: https://api.github.com/repos/docker/compose/releases/146766600",
+                        "Warn: release artifact v2.25.0 not signed: https://api.github.com/repos/docker/compose/releases/146766600",
+                        "Warn: release artifact v2.24.7 does not have provenance: https://api.github.com/repos/docker/compose/releases/144954606",
+                        "Warn: release artifact v2.24.7 not signed: https://api.github.com/repos/docker/compose/releases/144954606",
+                        "Warn: release artifact v2.24.6 does not have provenance: https://api.github.com/repos/docker/compose/releases/142153265",
+                        "Warn: release artifact v2.24.6 not signed: https://api.github.com/repos/docker/compose/releases/142153265",
+                        "Warn: release artifact v2.24.5 does not have provenance: https://api.github.com/repos/docker/compose/releases/139179155",
+                        "Warn: release artifact v2.24.5 not signed: https://api.github.com/repos/docker/compose/releases/139179155",
+                        "Warn: release artifact v2.24.4 does not have provenance: https://api.github.com/repos/docker/compose/releases/139010398",
+                        "Warn: release artifact v2.24.4 not signed: https://api.github.com/repos/docker/compose/releases/139010398"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project cryptographically signs release artifacts.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#signed-releases"
+                    }
+                },
+                {
+                    "name": "Token-Permissions",
+                    "score": 0,
+                    "reason": "non read-only tokens detected in GitHub workflows",
+                    "details": [
+                        "Info: topLevel 'contents' permission set to 'read': .github/workflows/ci.yml:25: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/ci.yml/main?enable=permissions",
+                        "Warn: jobLevel 'contents' permission set to 'write': .github/workflows/ci.yml:256: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/ci.yml/main?enable=permissions",
+                        "Warn: no topLevel permission defined: .github/workflows/codeql.yml:1: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/codeql.yml/main?enable=permissions",
+                        "Info: jobLevel 'actions' permission set to 'read': .github/workflows/codeql.yml:26: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/codeql.yml/main?enable=permissions",
+                        "Info: jobLevel 'contents' permission set to 'read': .github/workflows/codeql.yml:27: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/codeql.yml/main?enable=permissions",
+                        "Warn: no topLevel permission defined: .github/workflows/docs-upstream.yml:1: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/docs-upstream.yml/main?enable=permissions",
+                        "Info: topLevel 'contents' permission set to 'read': .github/workflows/merge.yml:15: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/merge.yml/main?enable=permissions",
+                        "Info: topLevel permissions set to 'read-all': .github/workflows/scorecards.yml:11: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/scorecards.yml/main?enable=permissions"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project's workflows follow the principle of least privilege.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#token-permissions"
+                    }
+                },
+                {
+                    "name": "Vulnerabilities",
+                    "score": 10,
+                    "reason": "no vulnerabilities detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has open, known unfixed vulnerabilities.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#vulnerabilities"
+                    }
+                }
+            ]
+        },
+        "failure_reason":""
+    },
+    {
+        "name":null,
+        "version":null,
+        "dependency_score":{
+            "date": "2024-03-18",
+            "score": 7.1,
+            "checks": [
+                {
+                    "name": "Binary-Artifacts",
+                    "score": 10,
+                    "reason": "no binaries found in the repo",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has generated executable (binary) artifacts in the source repository.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#binary-artifacts"
+                    }
+                },
+                {
+                    "name": "Branch-Protection",
+                    "score": -1,
+                    "reason": "internal error: error during branchesHandler.setup: internal error: githubv4.Query: Resource not accessible by integration",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the default and release branches are protected with GitHub's branch protection settings.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#branch-protection"
+                    }
+                },
+                {
+                    "name": "CI-Tests",
+                    "score": 10,
+                    "reason": "22 out of 22 merged PRs checked by a CI test -- score normalized to 10",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project runs tests before pull requests are merged.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#ci-tests"
+                    }
+                },
+                {
+                    "name": "CII-Best-Practices",
+                    "score": 0,
+                    "reason": "no badge detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has an OpenSSF (formerly CII) Best Practices Badge.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#cii-best-practices"
+                    }
+                },
+                {
+                    "name": "Code-Review",
+                    "score": 10,
+                    "reason": "22 out of last 22 changesets reviewed before merge -- score normalized to 10",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project requires code review before pull requests (aka merge requests) are merged.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#code-review"
+                    }
+                },
+                {
+                    "name": "Contributors",
+                    "score": 10,
+                    "reason": "39 different organizations found -- score normalized to 10",
+                    "details": [
+                        "Info: contributors work for BreizhJUG,Dockins,FyneHeroes,WP-Team-Bach,allons-y,amontourdeprogrammer,anonaddy,atlassian,breizhcamp,chad metcalf,ci-reporter,cnabio,compose-spec,containerd,daytonaio,degreed,depcheck,distribution,docker,docker-archive,docker-captains,dockersamples,docsorg,focus-on-systems,full city tech co.,github-beta,go-docker,goreleaser,jnr,jruby,librenms,magefile,maintainers,moby,neard,opencontainers,portapps,thajeztah,tilt-dev"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project has a set of contributors from multiple organizations (e.g., companies).",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#contributors"
+                    }
+                },
+                {
+                    "name": "Dangerous-Workflow",
+                    "score": 10,
+                    "reason": "no dangerous workflow patterns detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project's GitHub Action workflows avoid dangerous patterns.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#dangerous-workflow"
+                    }
+                },
+                {
+                    "name": "Dependency-Update-Tool",
+                    "score": 10,
+                    "reason": "update tool detected",
+                    "details": [
+                        "Info: Dependabot detected: .github/dependabot.yml:1"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project uses a dependency update tool.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#dependency-update-tool"
+                    }
+                },
+                {
+                    "name": "Fuzzing",
+                    "score": -1,
+                    "reason": "internal error: internal error: Client.Search.Code: Search.Code: GET https://api.github.com/search/code?q=github.com+docker+compose+repo%3Agoogle%2Foss-fuzz+in%3Afile+filename%3Aproject.yaml: 403 You have exceeded a secondary rate limit. Please wait a few minutes before you try again. If you reach out to GitHub Support for help, please include the request ID 5858:8923:4BF59:90008:65F859D0. []",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project uses fuzzing.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#fuzzing"
+                    }
+                },
+                {
+                    "name": "License",
+                    "score": 10,
+                    "reason": "license file detected",
+                    "details": [
+                        "Info: : LICENSE:1"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project has defined a license.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#license"
+                    }
+                },
+                {
+                    "name": "Maintained",
+                    "score": 10,
+                    "reason": "30 commit(s) out of 30 and 1 issue activity out of 30 found in the last 90 days -- score normalized to 10",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project is \"actively maintained\".",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#maintained"
+                    }
+                },
+                {
+                    "name": "Packaging",
+                    "score": -1,
+                    "reason": "no published package detected",
+                    "details": [
+                        "Warn: no GitHub publishing workflow detected"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project is published as a package that others can easily download, install, easily update, and uninstall.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#packaging"
+                    }
+                },
+                {
+                    "name": "Pinned-Dependencies",
+                    "score": -1,
+                    "reason": "internal error: error parsing shell code: Dockerfile:1:1: unclosed here-document 'EOT'",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has declared and pinned the dependencies of its build process.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#pinned-dependencies"
+                    }
+                },
+                {
+                    "name": "SAST",
+                    "score": -1,
+                    "reason": "internal error: Client.Search.Code: Search.Code: GET https://api.github.com/search/code?q=github+codeql-action+analyze+repo%3Adocker%2Fcompose+path%3A%2F.github%2Fworkflows: 403 You have exceeded a secondary rate limit. Please wait a few minutes before you try again. If you reach out to GitHub Support for help, please include the request ID 5858:8923:4BF0C:8FF6D:65F859CF. []",
+                    "details": [
+                        "Warn: 0 commits out of 30 are checked with a SAST tool"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project uses static code analysis.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#sast"
+                    }
+                },
+                {
+                    "name": "Security-Policy",
+                    "score": 0,
+                    "reason": "security policy file not detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has published a security policy.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#security-policy"
+                    }
+                },
+                {
+                    "name": "Signed-Releases",
+                    "score": 0,
+                    "reason": "0 out of 5 artifacts are signed or have provenance",
+                    "details": [
+                        "Warn: release artifact v2.25.0 does not have provenance: https://api.github.com/repos/docker/compose/releases/146766600",
+                        "Warn: release artifact v2.25.0 not signed: https://api.github.com/repos/docker/compose/releases/146766600",
+                        "Warn: release artifact v2.24.7 does not have provenance: https://api.github.com/repos/docker/compose/releases/144954606",
+                        "Warn: release artifact v2.24.7 not signed: https://api.github.com/repos/docker/compose/releases/144954606",
+                        "Warn: release artifact v2.24.6 does not have provenance: https://api.github.com/repos/docker/compose/releases/142153265",
+                        "Warn: release artifact v2.24.6 not signed: https://api.github.com/repos/docker/compose/releases/142153265",
+                        "Warn: release artifact v2.24.5 does not have provenance: https://api.github.com/repos/docker/compose/releases/139179155",
+                        "Warn: release artifact v2.24.5 not signed: https://api.github.com/repos/docker/compose/releases/139179155",
+                        "Warn: release artifact v2.24.4 does not have provenance: https://api.github.com/repos/docker/compose/releases/139010398",
+                        "Warn: release artifact v2.24.4 not signed: https://api.github.com/repos/docker/compose/releases/139010398"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project cryptographically signs release artifacts.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#signed-releases"
+                    }
+                },
+                {
+                    "name": "Token-Permissions",
+                    "score": 0,
+                    "reason": "non read-only tokens detected in GitHub workflows",
+                    "details": [
+                        "Info: topLevel 'contents' permission set to 'read': .github/workflows/ci.yml:25: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/ci.yml/main?enable=permissions",
+                        "Warn: jobLevel 'contents' permission set to 'write': .github/workflows/ci.yml:256: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/ci.yml/main?enable=permissions",
+                        "Warn: no topLevel permission defined: .github/workflows/codeql.yml:1: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/codeql.yml/main?enable=permissions",
+                        "Info: jobLevel 'actions' permission set to 'read': .github/workflows/codeql.yml:26: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/codeql.yml/main?enable=permissions",
+                        "Info: jobLevel 'contents' permission set to 'read': .github/workflows/codeql.yml:27: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/codeql.yml/main?enable=permissions",
+                        "Warn: no topLevel permission defined: .github/workflows/docs-upstream.yml:1: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/docs-upstream.yml/main?enable=permissions",
+                        "Info: topLevel 'contents' permission set to 'read': .github/workflows/merge.yml:15: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/merge.yml/main?enable=permissions",
+                        "Info: topLevel permissions set to 'read-all': .github/workflows/scorecards.yml:11: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/scorecards.yml/main?enable=permissions"
+                    ],
+                    "documentation": {
+                        "short": "Determines if the project's workflows follow the principle of least privilege.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#token-permissions"
+                    }
+                },
+                {
+                    "name": "Vulnerabilities",
+                    "score": 10,
+                    "reason": "no vulnerabilities detected",
+                    "details": null,
+                    "documentation": {
+                        "short": "Determines if the project has open, known unfixed vulnerabilities.",
+                        "url": "https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#vulnerabilities"
+                    }
+                }
+            ]
+        },
+        "failure_reason":""
+    }
+    ],
+    "unscored_dependencies":[
+    
+    ],
+    "failed_dependencies":[
+    
+    ]
+}

--- a/src/main/data_types/sbom_types/dependency.py
+++ b/src/main/data_types/sbom_types/dependency.py
@@ -78,8 +78,8 @@ class Dependency:
             "name": self.name,
             "version": self.version,
             "dependency_score": self.dependency_score.to_dict()
-            if self.dependency_score else "",
+            if self.dependency_score else None,
 
             "failure_reason": str(self.failure_reason)
-            if self.failure_reason else ""
+            if self.failure_reason else None
         }

--- a/src/main/frontend/web_api.py
+++ b/src/main/frontend/web_api.py
@@ -68,12 +68,13 @@ def update_current_status(update: SbomProcessorStatus):
     """
     global status
     status = update
-    print(f"Status updated: {asdict(status)}")
+
 
 
 @app.route("/get_current_status", methods=['GET'])
 def get_current_status():
     global status
+    print(f"Status updated: {asdict(status)}")
     return json.dumps(asdict(status))
 
 

--- a/src/tests/main/unit/data_types/sbom_types/test_dependency_manager.py
+++ b/src/tests/main/unit/data_types/sbom_types/test_dependency_manager.py
@@ -190,8 +190,8 @@ def test_dependency_manager_to_dict_filled(
     assert dep_dict["unscored_dependencies"] == \
         [{'name': 'github.com/repo/path',
           'version': '3.0',
-          'dependency_score': '',
-          'failure_reason': ''}]
+          'dependency_score': None,
+          'failure_reason': None}]
     assert isinstance(
         dep_dict["failed_dependencies"][0]["failure_reason"], str
         )


### PR DESCRIPTION
This commit is for user test and should display results the same way as earlier GUI. The update of OpenSSF removed 9 categories which is why they are no longer displayed. This commit also added some documentation which will be further elaborated in further issues. 
KNOWN ISSUES;
- inputting a non-json file will crash the website (not tested)
- the failed dependencies and reasons are not displayed although there is code for it. 
- The status reports are a bit weird but it seems to be coming from backend. 