### PR TITLE
140 looking up sboms

### DIFF
--- a/src/backend/models.py
+++ b/src/backend/models.py
@@ -64,6 +64,7 @@ class Dependency(db.Model):
     id = db.Column(db.Integer, autoincrement=True, primary_key=True)
     name = db.Column(db.String(255), unique=False)
     version = db.Column(db.String(255), unique=False)
+    # TODO: Should also store external references, at least of type "vcs".
 
     scorecard = db.relationship("Scorecard", backref="dependency", lazy=True,
                                 uselist=False)

--- a/src/backend/models.py
+++ b/src/backend/models.py
@@ -90,7 +90,7 @@ class SBOM(db.Model):
     """
     id = db.Column(db.Integer, autoincrement=True, primary_key=True)
     serial_number = db.Column(db.String(60), unique=False)
-    version = db.Column(db.String(255), unique=False)
+    version = db.Column(db.Integer, unique=False)
     repo_name = db.Column(db.String(255), unique=False)
     repo_version = db.Column(db.String(255), unique=False)
 
@@ -105,6 +105,8 @@ class SBOM(db.Model):
             dict: The dict representing the SBOM.
         """
         return {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.2",
             "serialNumber": self.serial_number,
             "version": self.version,
             "metadata": {

--- a/src/backend/routes.py
+++ b/src/backend/routes.py
@@ -101,8 +101,8 @@ def register_endpoints(app: Flask, db: SQLAlchemy):
         return jsonify(list(names)), 200
 
 
-    @app.route("/sbom/<platform>/<org>/<name>", methods=["GET"])
-    def get_sboms_by_name(platform: str, org: str, name: str):
+    @app.route("/sbom/<path:repo_name>", methods=["GET"])
+    def get_sboms_by_name(repo_name: str):
         """
         Gets a list of SBOMs with a specific name.
 
@@ -112,7 +112,6 @@ def register_endpoints(app: Flask, db: SQLAlchemy):
         Returns:
             json (array): The list of SBOMs.
         """
-        repo_name = f"{platform}/{org}/{name}"
         sboms = SBOM.query.filter_by(repo_name=repo_name).all()
         sbom_dicts = [sbom.to_dict() for sbom in sboms]
         return jsonify(sbom_dicts), 200

--- a/src/backend/routes.py
+++ b/src/backend/routes.py
@@ -101,8 +101,8 @@ def register_endpoints(app: Flask, db: SQLAlchemy):
         return jsonify(list(names)), 200
 
 
-    @app.route("/sbom/<repo_name>", methods=["GET"])
-    def get_sboms_by_name(repo_name: str):
+    @app.route("/sbom/<platform>/<org>/<name>", methods=["GET"])
+    def get_sboms_by_name(platform: str, org: str, name: str):
         """
         Gets a list of SBOMs with a specific name.
 
@@ -112,6 +112,7 @@ def register_endpoints(app: Flask, db: SQLAlchemy):
         Returns:
             json (array): The list of SBOMs.
         """
+        repo_name = f"{platform}/{org}/{name}"
         sboms = SBOM.query.filter_by(repo_name=repo_name).all()
         sbom_dicts = [sbom.to_dict() for sbom in sboms]
         return jsonify(sbom_dicts), 200

--- a/src/main/backend_communication.py
+++ b/src/main/backend_communication.py
@@ -41,7 +41,7 @@ class BackendCommunication:
         try:
             resp = requests.post(
                 self.host + "/sbom", json=sbom.to_dict(), timeout=5
-                )
+            )
             if resp.status_code == 500:
                 self.on_status_changed.invoke(
                     StepResponse(0, 0, 0, 0, "The sbom could not be uploaded")
@@ -69,10 +69,13 @@ class BackendCommunication:
             # Tell the user that the request timed out
             self.on_status_changed.invoke(
                 StepResponse(0, 0, 0, 0, "The request timed out")
-                )
+            )
 
         result: list[Sbom] = []
         if response.status_code != 200:
+            self.on_status_changed.invoke(
+                StepResponse(0, 0, 0, 0, "An error occurred in the database")
+            )
             return result
 
         for sbom in response.json():
@@ -94,8 +97,15 @@ class BackendCommunication:
             # Tell the user that the request timed out
             self.on_status_changed.invoke(
                 StepResponse(0, 0, 0, 0, "The request timed out")
-                )
-        return response.json() if response.status_code == 200 else []
+            )
+
+        if response.status_code != 200:
+            self.on_status_changed.invoke(
+                StepResponse(0, 0, 0, 0, "An error occurred in the database")
+            )
+            return []
+
+        return response.json()
 
 
 class BackendFetcher(DependencyScorer):

--- a/src/main/data_types/sbom_types/sbom.py
+++ b/src/main/data_types/sbom_types/sbom.py
@@ -145,6 +145,15 @@ class Sbom:
         name = ""
         version = ""
         try:
+            # TODO: The name of the component is not in the url.
+            #       According to the CycloneDX documentation,
+            #       each component has a name that can be accessed via
+            #       component["name"].
+            #       This should be fixed, preferably by storing the
+            #       URL in it's own variable in Dependency, so
+            #       that OSSQA adheres to the CycloneDX format,
+            #       which in turn makes the behavior of the program
+            #       more predictable.
             name = self._parse_git_url(
                 self._get_component_url(component=component)
                 )

--- a/src/main/data_types/sbom_types/sbom.py
+++ b/src/main/data_types/sbom_types/sbom.py
@@ -108,7 +108,7 @@ class Sbom:
 
         # Checks if name of SBOM exists
         try:
-            name = sbom_file["metadata"]["tools"][0]["name"]
+            name = sbom_file["metadata"]["component"]["name"]
         except (IndexError, KeyError):
             name = ""
 

--- a/src/main/frontend/cli.py
+++ b/src/main/frontend/cli.py
@@ -67,12 +67,16 @@ def create_parser() -> ArgumentParser:
     """
 
     run_type_group.add_argument(
-        "-a", "--analyze",
-        action="store_true", help="Analyze SBOM file."
+        "-a", "--analyze", action="store_true",
+        help="Analyze SBOM file."
+    )
+    run_type_group.add_argument(
+        "-s", "--sboms", action="store_true",
+        help="Lookup repository names of SBOMs in the database."
     )
     run_type_group.add_argument(
         "-l", "--lookup", action="store_true",
-        help="Lookup SBOM in database."
+        help="Lookup details of an SBOM in the database."
     )
 
 
@@ -128,8 +132,8 @@ def create_parser() -> ArgumentParser:
 
     # Lookup command
     parser.add_argument(
-        "-i", "--id", metavar='\b', type=int,
-        help="    The ID of the SBOM."
+        "-n", "--name", metavar='\b', type=str,
+        help="    The repository name of the SBOM."
     )
 
     # Shared
@@ -279,23 +283,23 @@ def parse_analyze_arguments(args: Namespace) -> tuple[str, UserRequirements]:
 
 def parse_lookup_arguments(args: Namespace) -> int:
     """
-    Parses the lookup arguments and returns the ID.
+    Parses the lookup arguments and returns the repository name.
 
     Args:
         args (Namespace): The parsed command-line arguments.
 
     Returns:
-        int: The ID extracted from the arguments.
+        str: The repository name extracted from the arguments.
 
     Raises:
-        SystemExit: If the required argument [-i | --id] is missing.
+        SystemExit: If the required argument [-n | --name] is missing.
     """
-    if not args.id:
-        print("Please add the argument [-i | --id] [ID]")
+    if not args.name:
+        print("Please add the argument [-n | --name] [NAME]")
         exit(1)
 
-    smob_id: int = args.id
-    return smob_id
+    repo_name: str = args.name
+    return repo_name
 
 
 def parse_arguments_shared(args: Namespace) -> tuple[str, bool]:
@@ -405,8 +409,7 @@ def color_scores(scores: list[list[Dependency, float]]) -> \
     return colored_scores
 
 
-def analyze(args: Namespace) -> None:
-    print("Analyzing")
+def analyze_sbom(args: Namespace) -> None:
     path, requirements = parse_analyze_arguments(args)
     with open(path, encoding='utf-8') as f:
         sbom_dict: dict = json.load(f)
@@ -438,9 +441,14 @@ def analyze(args: Namespace) -> None:
         print(json.dumps(json_results))
 
 
-def lookup(args: Namespace):
-    print("Looking up")
-    sbom_id = parse_lookup_arguments(args)
+def lookup_sbom_names(args: Namespace) -> None:
+    pass
+
+
+def lookup_sbom_details(args: Namespace) -> None:
+    repo_name = parse_lookup_arguments(args)
+    print(f"{repo_name = }")
+
 
 
 def run_cli():
@@ -452,9 +460,11 @@ def run_cli():
     output, verbose = parse_arguments_shared(args)
 
     if args.analyze:
-        analyze(args)
+        analyze_sbom(args)
+    elif args.sboms:
+        lookup_sbom_names(args)
     elif args.lookup:
-        lookup(args)
+        lookup_sbom_details(args)
 
 
 def fill_with_test_scores(dependencies: list[Dependency]) -> list[Dependency]:

--- a/src/main/frontend/cli.py
+++ b/src/main/frontend/cli.py
@@ -123,12 +123,6 @@ def create_parser() -> ArgumentParser:
         help="    The git token."
     )
 
-    parser.add_argument(
-        "--backend", metavar='\b', type=str,
-        default=constants.HOST,
-        help="The URL of the backend."
-    )
-
 
     # Lookup command
     parser.add_argument(
@@ -146,6 +140,12 @@ def create_parser() -> ArgumentParser:
     parser.add_argument(
         "-v", "--verbose", action="store_true",
         help="Verbose output."
+    )
+
+    parser.add_argument(
+        "--backend", metavar='\b', type=str,
+        default=constants.HOST,
+        help="The URL of the backend."
     )
 
     return parser
@@ -315,6 +315,7 @@ def parse_arguments_shared(args: Namespace) -> tuple[str, bool]:
     """
     output: str = "table"
     verbose: bool = False
+    backend: str = constants.HOST
 
     if args.output:
         output: str = args.output
@@ -322,7 +323,10 @@ def parse_arguments_shared(args: Namespace) -> tuple[str, bool]:
     if args.verbose:
         verbose: bool = args.verbose
 
-    return output, verbose
+    if args.backend:
+        backend: str = constants.HOST
+
+    return output, verbose, backend
 
 
 def calculate_mean_score(dependency: Dependency, decimals: int = 1) -> float:
@@ -410,13 +414,15 @@ def color_scores(scores: list[list[Dependency, float]]) -> \
 
 
 def analyze_sbom(args: Namespace) -> None:
+    output, verbose, backend = parse_arguments_shared(args)
     path, requirements = parse_analyze_arguments(args)
+
     with open(path, encoding='utf-8') as f:
         sbom_dict: dict = json.load(f)
         sbom = Sbom(sbom_dict)
 
     # print(sbom.to_dict())
-    api = FrontEndAPI(args.backend)
+    api = FrontEndAPI(backend)
     # TODO handle errors
 
     scored_sbom: Sbom = api.analyze_sbom(sbom, requirements)
@@ -442,13 +448,12 @@ def analyze_sbom(args: Namespace) -> None:
 
 
 def lookup_sbom_names(args: Namespace) -> None:
-    pass
+    output, verbose, backend = parse_arguments_shared(args)
 
 
 def lookup_sbom_details(args: Namespace) -> None:
+    output, verbose, backend = parse_arguments_shared(args)
     repo_name = parse_lookup_arguments(args)
-    print(f"{repo_name = }")
-
 
 
 def run_cli():
@@ -457,7 +462,6 @@ def run_cli():
     """
     parser: ArgumentParser = create_parser()
     args: Namespace = parser.parse_args()
-    output, verbose = parse_arguments_shared(args)
 
     if args.analyze:
         analyze_sbom(args)

--- a/src/main/frontend/cli.py
+++ b/src/main/frontend/cli.py
@@ -462,6 +462,36 @@ def lookup_sbom_names(args: Namespace) -> None:
 def lookup_sbom_details(args: Namespace) -> None:
     output, verbose, backend = parse_arguments_shared(args)
     repo_name = parse_lookup_arguments(args)
+    front_end_api = FrontEndAPI(backend)
+    sboms = front_end_api.lookup_previous_sboms(repo_name)
+
+    if output != "json":
+        table_data = []
+        for sbom in sboms:
+            dependencies = sbom.dependency_manager.get_dependencies_by_filter(
+                lambda _: True
+            )
+            sbom_data = [
+                sbom.serial_number,
+                sbom.version,
+                sbom.repo_name,
+                sbom.repo_version,
+                len(dependencies),
+            ]
+            table_data.append(sbom_data)
+
+        table_headers = [
+            "Serial number",
+            "Version",
+            "Repo name",
+            "Repo version",
+            "Dependency count"
+        ]
+        table = tabulate(table_data, headers=table_headers)
+        print(table)
+    else:
+        sbom_dicts = [sbom.to_dict() for sbom in sboms]
+        print(json.dumps(sbom_dicts))
 
 
 def run_cli():

--- a/src/main/frontend/cli.py
+++ b/src/main/frontend/cli.py
@@ -324,7 +324,7 @@ def parse_arguments_shared(args: Namespace) -> tuple[str, bool]:
         verbose: bool = args.verbose
 
     if args.backend:
-        backend: str = constants.HOST
+        backend: str = args.backend
 
     return output, verbose, backend
 

--- a/src/main/frontend/cli.py
+++ b/src/main/frontend/cli.py
@@ -449,6 +449,14 @@ def analyze_sbom(args: Namespace) -> None:
 
 def lookup_sbom_names(args: Namespace) -> None:
     output, verbose, backend = parse_arguments_shared(args)
+    front_end_api = FrontEndAPI(backend)
+    sbom_names = front_end_api.lookup_stored_sboms()
+
+    if output != "json":
+        table = tabulate([sbom_names], headers=["Repository Names"])
+        print(table)
+    else:
+        print(json.dumps(sbom_names))
 
 
 def lookup_sbom_details(args: Namespace) -> None:

--- a/src/main/frontend/cli.py
+++ b/src/main/frontend/cli.py
@@ -414,6 +414,12 @@ def color_scores(scores: list[list[Dependency, float]]) -> \
 
 
 def analyze_sbom(args: Namespace) -> None:
+    """
+    Executes the command that analyzes an SBOM.
+
+    Args:
+        args (Namespace): The parsed arguments of the program.
+    """
     output, verbose, backend = parse_arguments_shared(args)
     path, requirements = parse_analyze_arguments(args)
 
@@ -448,6 +454,12 @@ def analyze_sbom(args: Namespace) -> None:
 
 
 def lookup_sbom_names(args: Namespace) -> None:
+    """
+    Executes the command that fetches all SBOM names from the backend.
+
+    Args:
+        args (Namespace): The parsed arguments of the program.
+    """
     output, verbose, backend = parse_arguments_shared(args)
     front_end_api = FrontEndAPI(backend)
     sbom_names = front_end_api.lookup_stored_sboms()
@@ -460,6 +472,13 @@ def lookup_sbom_names(args: Namespace) -> None:
 
 
 def lookup_sbom_details(args: Namespace) -> None:
+    """
+    Executes the command that fetches all SBOMs of a specific name
+    from the backend.
+
+    Args:
+        args (Namespace): The parsed arguments of the program.
+    """
     output, verbose, backend = parse_arguments_shared(args)
     repo_name = parse_lookup_arguments(args)
     front_end_api = FrontEndAPI(backend)

--- a/src/main/frontend/cli.py
+++ b/src/main/frontend/cli.py
@@ -434,7 +434,7 @@ def analyze_sbom(args: Namespace) -> None:
     # scores = fill_with_test_scores(scores)
     # END TEMPORARY
 
-    if args.output != "json":
+    if output != "json":
         mean_scores = get_mean_scores(scores)
         mean_scores = sorted(mean_scores, key=lambda x: x[1])
         mean_scores = color_scores(mean_scores)

--- a/src/main/sbom_processor.py
+++ b/src/main/sbom_processor.py
@@ -137,7 +137,10 @@ class SbomProcessor:
             list[str]: The list of the SBOM names
         """
         # Look up stored SBOMs
-        return self.backend_communication.get_sbom_names()
+        self._set_event_state(SbomProcessorStates.FETCH_DATABASE)
+        sbom_names = self.backend_communication.get_sbom_names()
+        self._set_event_state(SbomProcessorStates.COMPLETED)
+        return sbom_names
 
     def lookup_previous_sboms(self, name: str) -> list[Sbom]:
         """
@@ -149,4 +152,7 @@ class SbomProcessor:
         Returns:
             list[dict]: The list of the SBOMs with the same name.
         """
-        return self.backend_communication.get_sboms_by_name(name)
+        self._set_event_state(SbomProcessorStates.FETCH_DATABASE)
+        sboms = self.backend_communication.get_sboms_by_name(name)
+        self._set_event_state(SbomProcessorStates.COMPLETED)
+        return sboms


### PR DESCRIPTION
This PR adds functionality for getting SBOM names and getting SBOMs by specifying their names from database.

To get SBOM names, run the following command:
```docker compose run ossqa-cli -s```

To get SBOMs with a certain name, run the following command:
```docker compose run ossqa-cli -l -n [NAME]```

Currently the last command will show that the SBOM has no dependencies. This is because of how dependencies are parsed when creating a new Sbom object, and partially because of what data about dependencies is stored in the database. I have written TODOs that comment on this in ```sbom.py``` and ```models.py```.