### PR TITLE
Fixed the Docker file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,10 @@ services:
       dockerfile: src/main/frontend/cli.Dockerfile
     depends_on:
       - ossqa-database
+    volumes:
+      - type: bind
+        source: ./sboms
+        target: /sboms
     env_file: .env
 
   ossqa-web:

--- a/src/main/frontend/cli.Dockerfile
+++ b/src/main/frontend/cli.Dockerfile
@@ -5,8 +5,6 @@ WORKDIR /app
 # Copy relevant project files
 COPY src/main ./main
 COPY src/cli_main.py .
-# Example SBOM copied until files can be sent in from host
-COPY ./sboms/ .
 
 # Create, activate, and setup python virtual environment
 RUN python3 -m venv /app/venv


### PR DESCRIPTION
The Docker file is modified so you can use local SBOM:s while running the program withi the sboms within the folder "sboms".

Command to run now:

- docker compose run ossqa-cli analyze /sboms/sbom-file.json

sbom-file.json is the name of whatever file in the sbom folder you want to analyze, you don't need to rebuild Docker anymore